### PR TITLE
Modernize Mawaqeet for HA 2026.3+ (Gold, Lovelace card, blueprints)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,29 +68,38 @@ When enabled (default), the integration fires reminder events before each upcomi
 
 ### Automations
 
-The [adhan blueprint](blueprints/adhan.yaml) plays adhan when a Mawaqeet prayer time fires. Import it from **Settings → Automations → Blueprints** (or place `blueprints/adhan.yaml` in your config `blueprints/` folder).
+Five automation blueprints ship with this repository. Use the **Import** badges to open the blueprint import dialog on your Home Assistant instance ([My Home Assistant](https://my.home-assistant.io) link). You can also import manually from **Settings → Automations → Blueprints**, or copy YAML into your config `blueprints/` folder.
 
-#### Blueprint options
+| Blueprint | Use when | Import |
+| --- | --- | --- |
+| [Adhan (Home Assistant)](blueprints/adhan_home_assistant.yaml) | Play adhan on prayer time via Sonos, Cast, and other `media_player` entities (not Music Assistant) | [![Import blueprint][import-adhan-ha-badge]][import-adhan-ha] |
+| [Adhan (Music Assistant)](blueprints/adhan_music_assistant.yaml) | Play adhan via `media_player` entities from the [Music Assistant](https://www.home-assistant.io/integrations/music_assistant/) integration | [![Import blueprint][import-adhan-ma-badge]][import-adhan-ma] |
+| [Fajr wake-up](blueprints/fajr_wakeup.yaml) | Gradually turn on lights (and optional tone) at Fajr or the Mawaqeet Fajr reminder; use adhan blueprints for full adhan | [![Import blueprint][import-fajr-wakeup-badge]][import-fajr-wakeup] |
+| [Prayer reminder notification](blueprints/prayer_reminder_notify.yaml) | Send a notification or TTS when a Mawaqeet prayer reminder fires | [![Import blueprint][import-prayer-reminder-badge]][import-prayer-reminder] |
+| [Prayer time lighting](blueprints/prayer_time_lights.yaml) | Control lights or scenes when a Mawaqeet prayer time occurs | [![Import blueprint][import-prayer-lights-badge]][import-prayer-lights] |
+
+#### Blueprint options (both adhan blueprints)
 
 | Input | Description |
 | --- | --- |
 | Location | Mawaqeet device (prayer time trigger) |
 | Playback mode | **Media playback** (normal play) or **Announcement** (duck/pause other audio where supported) |
-| Player backend | **Home Assistant** (`media_player.play_media`) or **Music Assistant** (`music_assistant.*` actions) |
 | Enable per prayer | Toggle Fajr, Dhuhr, Asr, Maghrib, Ishaa |
-| Fajr adhan (playback) | Player + file for Fajr in media playback mode |
-| Other prayers adhan (playback) | Player + file for Dhuhr–Ishaa in media playback mode |
-| Fajr adhan (announcement) | Player + file for Fajr in announcement mode (can differ from playback) |
-| Other prayers adhan (announcement) | Player + file for Dhuhr–Ishaa in announcement mode |
-| Announcement volume (Fajr / other) | Optional 0–100 for Music Assistant announcements only |
+| Fajr media player | `media_player` for Fajr (filtered by blueprint: all players vs MA-only) |
+| Other prayers media player | `media_player` for Dhuhr–Ishaa |
+| Fajr adhan audio (playback) | Audio file for Fajr in media playback mode |
+| Other prayers adhan audio (playback) | Audio for Dhuhr–Ishaa in media playback mode |
+| Fajr adhan audio (announcement) | Audio for Fajr in announcement mode (can differ from playback) |
+| Other prayers adhan audio (announcement) | Audio for Dhuhr–Ishaa in announcement mode |
+| Announcement volume (Fajr / other) | Music Assistant blueprint only: optional 0–100 |
 
-**Fajr vs other prayers:** Use the four media selectors to use a different clip or speaker for Fajr than for the rest of the day, and to use different assets for announcement vs full playback (e.g. short Fajr announce on kitchen speaker, full adhan on living room for playback).
+**Fajr vs other prayers:** Pick separate players and audio files for Fajr and for the rest of the day. Use different announcement vs playback clips if you want a short announce at Fajr and full adhan elsewhere.
 
-**Home Assistant + announcement:** Uses `announce: true` on `media_player.play_media` (works best on Sonos and similar players).
+**Home Assistant blueprint:** Uses `media_player.play_media`. Announcement mode sets `announce: true` (works best on Sonos and similar players). Do not select `media_player.ma_*` entities — use the Music Assistant blueprint for those.
 
-**Music Assistant:** Requires the [Music Assistant](https://www.home-assistant.io/integrations/music_assistant/) integration. Target MA media players (e.g. `media_player.ma_kitchen`). For announcements, local files under `/config/www/` (`http://<your-ha>/local/...`) or `http(s)` URLs work reliably; other media paths are resolved via `media_source.resolve_media` before playback.
+**Music Assistant blueprint:** Uses `music_assistant.play_media` and `music_assistant.play_announcement`. Player selectors list only Music Assistant players. For announcements, local files under `/config/www/` (`http://<your-ha>/local/...`) or `http(s)` URLs work reliably; other paths are resolved via `media_source.resolve_media`.
 
-**Defaults for existing setups:** Player backend **Home Assistant**, playback mode **Media playback** — same behavior as earlier blueprint versions if you re-create the automation and fill the four media fields (duplicate playback settings into announcement fields if you want the same audio in both modes).
+**Migration from the old combined `adhan.yaml` blueprint:** Import the Home Assistant or Music Assistant blueprint (badges above), then create a new automation. Map your old combined media picks to **player** + **audio** inputs (same speaker and file as before).
 
 Example (Music Assistant, Fajr announcement):
 
@@ -249,3 +258,13 @@ MIT — see [LICENSE](LICENSE).
 [license-shield]: https://img.shields.io/github/license/oraad/ha-mawaqeet.svg?style=for-the-badge
 [releases-shield]: https://img.shields.io/github/release/oraad/ha-mawaqeet.svg?style=for-the-badge
 [releases]: https://github.com/oraad/ha-mawaqeet/releases
+[import-adhan-ha-badge]: https://my.home-assistant.io/badges/blueprint_import.svg
+[import-adhan-ha]: https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Foraad%2Fha-mawaqeet%2Fblob%2Fmain%2Fblueprints%2Fadhan_home_assistant.yaml
+[import-adhan-ma-badge]: https://my.home-assistant.io/badges/blueprint_import.svg
+[import-adhan-ma]: https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Foraad%2Fha-mawaqeet%2Fblob%2Fmain%2Fblueprints%2Fadhan_music_assistant.yaml
+[import-fajr-wakeup-badge]: https://my.home-assistant.io/badges/blueprint_import.svg
+[import-fajr-wakeup]: https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Foraad%2Fha-mawaqeet%2Fblob%2Fmain%2Fblueprints%2Ffajr_wakeup.yaml
+[import-prayer-reminder-badge]: https://my.home-assistant.io/badges/blueprint_import.svg
+[import-prayer-reminder]: https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Foraad%2Fha-mawaqeet%2Fblob%2Fmain%2Fblueprints%2Fprayer_reminder_notify.yaml
+[import-prayer-lights-badge]: https://my.home-assistant.io/badges/blueprint_import.svg
+[import-prayer-lights]: https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Foraad%2Fha-mawaqeet%2Fblob%2Fmain%2Fblueprints%2Fprayer_time_lights.yaml

--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ Home Assistant integration for Islamic prayer times (Mawaqeet), calculated local
 
 ### HACS (recommended)
 
-1. Add this repository as a [custom repository](https://hacs.xyz/docs/faq/custom_repositories/) in HACS (category: Integration).
-2. Install **Mawaqeet** from the HACS Integrations tab.
-3. Restart Home Assistant.
+[![Open in HACS][hacs-badge]][hacs]
+
+Requires [HACS](https://hacs.xyz/). If this repository is not listed yet, add `https://github.com/oraad/ha-mawaqeet` as a [custom repository](https://hacs.xyz/docs/faq/custom_repositories/) (category: **Integration**), then use the button above.
+
+1. Install **Mawaqeet** from the HACS Integrations tab.
+2. Restart Home Assistant.
 
 ### Manual
 
@@ -258,6 +261,8 @@ MIT — see [LICENSE](LICENSE).
 [license-shield]: https://img.shields.io/github/license/oraad/ha-mawaqeet.svg?style=for-the-badge
 [releases-shield]: https://img.shields.io/github/release/oraad/ha-mawaqeet.svg?style=for-the-badge
 [releases]: https://github.com/oraad/ha-mawaqeet/releases
+[hacs-badge]: https://my.home-assistant.io/badges/hacs_repository.svg
+[hacs]: https://my.home-assistant.io/redirect/hacs_repository/?owner=oraad&repository=ha-mawaqeet&category=integration
 [import-adhan-ha-badge]: https://my.home-assistant.io/badges/blueprint_import.svg
 [import-adhan-ha]: https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Foraad%2Fha-mawaqeet%2Fblob%2Fmain%2Fblueprints%2Fadhan_home_assistant.yaml
 [import-adhan-ma-badge]: https://my.home-assistant.io/badges/blueprint_import.svg

--- a/blueprints/adhan_home_assistant.yaml
+++ b/blueprints/adhan_home_assistant.yaml
@@ -1,0 +1,196 @@
+blueprint:
+  name: Adhan (Home Assistant)
+  description: >-
+    Play adhan on prayer time through Home Assistant media_player entities
+    (Sonos, Cast, and similar). Do not select Music Assistant players
+    (media_player.ma_*); use the Music Assistant adhan blueprint for those.
+    Supports media playback or announcement mode, with separate players and
+    audio for Fajr vs other prayers.
+  domain: automation
+  input:
+    device_id:
+      name: Location
+      description: Select Mawaqeet device
+      selector:
+        device:
+          filter:
+            integration: mawaqeet
+    playback_mode:
+      name: Playback mode
+      description: >-
+        Media playback plays the adhan normally. Announcement ducks or pauses
+        other audio on supported players (for example Sonos).
+      default: media_playback
+      selector:
+        select:
+          options:
+            - label: Media playback
+              value: media_playback
+            - label: Announcement
+              value: announcement
+    enable_fajr:
+      name: 'Enable: Fajr Adhan'
+      default: true
+      selector:
+        boolean: {}
+    enable_dhuhr:
+      name: 'Enable: Dhuhr Adhan'
+      default: true
+      selector:
+        boolean: {}
+    enable_asr:
+      name: 'Enable: Asr Adhan'
+      default: true
+      selector:
+        boolean: {}
+    enable_maghrib:
+      name: 'Enable: Maghrib Adhan'
+      default: true
+      selector:
+        boolean: {}
+    enable_ishaa:
+      name: 'Enable: Ishaa Adhan'
+      default: true
+      selector:
+        boolean: {}
+    player_fajr:
+      name: Fajr media player
+      description: >-
+        media_player entity for Fajr (not Music Assistant). Same player is used
+        for playback and announcement modes.
+      selector:
+        entity:
+          filter:
+            - domain: media_player
+    player_other:
+      name: Other prayers media player
+      description: >-
+        media_player entity for Dhuhr through Ishaa (not Music Assistant).
+      selector:
+        entity:
+          filter:
+            - domain: media_player
+    media_fajr_playback:
+      name: Fajr adhan audio (playback)
+      description: Adhan audio file for Fajr when using media playback mode.
+      selector:
+        media:
+          accept:
+            - audio/*
+            - music
+    media_other_playback:
+      name: Other prayers adhan audio (playback)
+      description: Adhan audio for Dhuhr through Ishaa in media playback mode.
+      selector:
+        media:
+          accept:
+            - audio/*
+            - music
+    media_fajr_announce:
+      name: Fajr adhan audio (announcement)
+      description: Adhan audio for Fajr in announcement mode (can differ from playback).
+      selector:
+        media:
+          accept:
+            - audio/*
+            - music
+    media_other_announce:
+      name: Other prayers adhan audio (announcement)
+      description: Adhan audio for Dhuhr through Ishaa in announcement mode.
+      selector:
+        media:
+          accept:
+            - audio/*
+            - music
+
+trigger:
+  - platform: device
+    domain: mawaqeet
+    device_id: !input device_id
+    type: prayer_time
+
+variables:
+  playback_mode: !input playback_mode
+  enable_fajr: !input enable_fajr
+  enable_dhuhr: !input enable_dhuhr
+  enable_asr: !input enable_asr
+  enable_maghrib: !input enable_maghrib
+  enable_ishaa: !input enable_ishaa
+  current_prayer: "{{ trigger.event.data.prayer }}"
+  player_fajr: !input player_fajr
+  player_other: !input player_other
+  media_fajr_playback: !input media_fajr_playback
+  media_other_playback: !input media_other_playback
+  media_fajr_announce: !input media_fajr_announce
+  media_other_announce: !input media_other_announce
+  adhan_entity_id: >-
+    {% if current_prayer == 'fajr' %}
+      {{ player_fajr }}
+    {% else %}
+      {{ player_other }}
+    {% endif %}
+  adhan_media_content_id: >-
+    {% if playback_mode == 'announcement' %}
+      {% if current_prayer == 'fajr' %}
+        {{ media_fajr_announce.media_content_id }}
+      {% else %}
+        {{ media_other_announce.media_content_id }}
+      {% endif %}
+    {% else %}
+      {% if current_prayer == 'fajr' %}
+        {{ media_fajr_playback.media_content_id }}
+      {% else %}
+        {{ media_other_playback.media_content_id }}
+      {% endif %}
+    {% endif %}
+  adhan_media_content_type: >-
+    {% if playback_mode == 'announcement' %}
+      {% if current_prayer == 'fajr' %}
+        {{ media_fajr_announce.media_content_type }}
+      {% else %}
+        {{ media_other_announce.media_content_type }}
+      {% endif %}
+    {% else %}
+      {% if current_prayer == 'fajr' %}
+        {{ media_fajr_playback.media_content_type }}
+      {% else %}
+        {{ media_other_playback.media_content_type }}
+      {% endif %}
+    {% endif %}
+
+condition:
+  - condition: template
+    value_template: >-
+      {% set p = trigger.event.data.prayer %}
+      {{ (p == 'fajr' and enable_fajr) or (p == 'dhuhr' and enable_dhuhr) or
+         (p == 'asr' and enable_asr) or (p == 'maghrib' and enable_maghrib) or
+         (p == 'ishaa' and enable_ishaa) }}
+
+action:
+  - event: adhan_event
+    event_data:
+      prayer: "{{ current_prayer }}"
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: "{{ playback_mode == 'media_playback' }}"
+        sequence:
+          - action: media_player.play_media
+            target:
+              entity_id: "{{ adhan_entity_id }}"
+            data:
+              media_content_id: "{{ adhan_media_content_id }}"
+              media_content_type: "{{ adhan_media_content_type }}"
+      - conditions:
+          - condition: template
+            value_template: "{{ playback_mode == 'announcement' }}"
+        sequence:
+          - action: media_player.play_media
+            target:
+              entity_id: "{{ adhan_entity_id }}"
+            data:
+              media_content_id: "{{ adhan_media_content_id }}"
+              media_content_type: "{{ adhan_media_content_type }}"
+              announce: true
+
+mode: single

--- a/blueprints/adhan_music_assistant.yaml
+++ b/blueprints/adhan_music_assistant.yaml
@@ -1,9 +1,10 @@
 blueprint:
-  name: Adhan
+  name: Adhan (Music Assistant)
   description: >-
-    Play adhan on prayer time via Home Assistant media players or Music Assistant.
-    Supports normal playback or announcement mode, with separate media for Fajr
-    vs other prayers (playback and announcement).
+    Play adhan on prayer time through Music Assistant media players
+    (media_player entities from the Music Assistant integration). Requires
+    the Music Assistant integration. Supports media playback or announcement
+    mode, with separate players and audio for Fajr vs other prayers.
   domain: automation
   input:
     device_id:
@@ -17,7 +18,7 @@ blueprint:
       name: Playback mode
       description: >-
         Media playback plays the adhan normally. Announcement ducks or pauses
-        other audio on supported players (Home Assistant announce or Music Assistant).
+        other audio on the player.
       default: media_playback
       selector:
         select:
@@ -26,19 +27,6 @@ blueprint:
               value: media_playback
             - label: Announcement
               value: announcement
-    player_backend:
-      name: Player backend
-      description: >-
-        Home Assistant uses media_player.play_media. Music Assistant requires
-        the Music Assistant integration and MA media player entities.
-      default: home_assistant
-      selector:
-        select:
-          options:
-            - label: Home Assistant
-              value: home_assistant
-            - label: Music Assistant
-              value: music_assistant
     enable_fajr:
       name: 'Enable: Fajr Adhan'
       default: true
@@ -64,35 +52,64 @@ blueprint:
       default: true
       selector:
         boolean: {}
-    media_adhan_fajr:
-      name: Fajr adhan (playback)
-      description: Media player and adhan file for Fajr when using media playback mode.
-      selector:
-        media:
-    media_adhan:
-      name: Other prayers adhan (playback)
-      description: Media player and adhan for Dhuhr through Ishaa in media playback mode.
-      selector:
-        media:
-    media_announce_fajr:
-      name: Fajr adhan (announcement)
+    player_fajr:
+      name: Fajr Music Assistant player
       description: >-
-        Media player and adhan for Fajr in announcement mode. For Music Assistant,
-        prefer files in /config/www or http(s) URLs.
+        Music Assistant media_player for Fajr (for example media_player.ma_kitchen).
+      selector:
+        entity:
+          filter:
+            - domain: media_player
+              integration: music_assistant
+    player_other:
+      name: Other prayers Music Assistant player
+      description: Music Assistant media_player for Dhuhr through Ishaa.
+      selector:
+        entity:
+          filter:
+            - domain: media_player
+              integration: music_assistant
+    media_fajr_playback:
+      name: Fajr adhan audio (playback)
+      description: Adhan audio file for Fajr when using media playback mode.
       selector:
         media:
-    media_announce_other:
-      name: Other prayers adhan (announcement)
+          accept:
+            - audio/*
+            - music
+    media_other_playback:
+      name: Other prayers adhan audio (playback)
+      description: Adhan audio for Dhuhr through Ishaa in media playback mode.
+      selector:
+        media:
+          accept:
+            - audio/*
+            - music
+    media_fajr_announce:
+      name: Fajr adhan audio (announcement)
       description: >-
-        Media player and adhan for Dhuhr through Ishaa in announcement mode.
-        For Music Assistant, prefer files in /config/www or http(s) URLs.
+        Adhan audio for Fajr in announcement mode. Prefer files in /config/www
+        or http(s) URLs.
       selector:
         media:
+          accept:
+            - audio/*
+            - music
+    media_other_announce:
+      name: Other prayers adhan audio (announcement)
+      description: >-
+        Adhan audio for Dhuhr through Ishaa in announcement mode. Prefer files
+        in /config/www or http(s) URLs.
+      selector:
+        media:
+          accept:
+            - audio/*
+            - music
     announce_volume_fajr:
-      name: Fajr announcement volume (Music Assistant)
+      name: Fajr announcement volume
       description: >-
-        Optional forced volume (0–100) for Fajr announcements on Music Assistant.
-        Leave empty to use the player default.
+        Optional forced volume (0–100) for Fajr announcements. Leave empty to
+        use the player default.
       selector:
         number:
           min: 0
@@ -100,10 +117,10 @@ blueprint:
           step: 1
           mode: slider
     announce_volume:
-      name: Other prayers announcement volume (Music Assistant)
+      name: Other prayers announcement volume
       description: >-
-        Optional forced volume (0–100) for other prayer announcements on Music Assistant.
-        Leave empty to use the player default.
+        Optional forced volume (0–100) for other prayer announcements. Leave
+        empty to use the player default.
       selector:
         number:
           min: 0
@@ -119,59 +136,52 @@ trigger:
 
 variables:
   playback_mode: !input playback_mode
-  player_backend: !input player_backend
   enable_fajr: !input enable_fajr
   enable_dhuhr: !input enable_dhuhr
   enable_asr: !input enable_asr
   enable_maghrib: !input enable_maghrib
   enable_ishaa: !input enable_ishaa
   current_prayer: "{{ trigger.event.data.prayer }}"
-  media_adhan_fajr: !input media_adhan_fajr
-  media_adhan: !input media_adhan
-  media_announce_fajr: !input media_announce_fajr
-  media_announce_other: !input media_announce_other
+  player_fajr: !input player_fajr
+  player_other: !input player_other
+  media_fajr_playback: !input media_fajr_playback
+  media_other_playback: !input media_other_playback
+  media_fajr_announce: !input media_fajr_announce
+  media_other_announce: !input media_other_announce
   announce_volume_fajr: !input announce_volume_fajr
   announce_volume: !input announce_volume
   adhan_entity_id: >-
-    {% if playback_mode == 'announcement' %}
-      {% if current_prayer == 'fajr' %}
-        {{ media_announce_fajr.entity_id }}
-      {% else %}
-        {{ media_announce_other.entity_id }}
-      {% endif %}
+    {% if current_prayer == 'fajr' %}
+      {{ player_fajr }}
     {% else %}
-      {% if current_prayer == 'fajr' %}
-        {{ media_adhan_fajr.entity_id }}
-      {% else %}
-        {{ media_adhan.entity_id }}
-      {% endif %}
+      {{ player_other }}
     {% endif %}
   adhan_media_content_id: >-
     {% if playback_mode == 'announcement' %}
       {% if current_prayer == 'fajr' %}
-        {{ media_announce_fajr.media_content_id }}
+        {{ media_fajr_announce.media_content_id }}
       {% else %}
-        {{ media_announce_other.media_content_id }}
+        {{ media_other_announce.media_content_id }}
       {% endif %}
     {% else %}
       {% if current_prayer == 'fajr' %}
-        {{ media_adhan_fajr.media_content_id }}
+        {{ media_fajr_playback.media_content_id }}
       {% else %}
-        {{ media_adhan.media_content_id }}
+        {{ media_other_playback.media_content_id }}
       {% endif %}
     {% endif %}
   adhan_media_content_type: >-
     {% if playback_mode == 'announcement' %}
       {% if current_prayer == 'fajr' %}
-        {{ media_announce_fajr.media_content_type }}
+        {{ media_fajr_announce.media_content_type }}
       {% else %}
-        {{ media_announce_other.media_content_type }}
+        {{ media_other_announce.media_content_type }}
       {% endif %}
     {% else %}
       {% if current_prayer == 'fajr' %}
-        {{ media_adhan_fajr.media_content_type }}
+        {{ media_fajr_playback.media_content_type }}
       {% else %}
-        {{ media_adhan.media_content_type }}
+        {{ media_other_playback.media_content_type }}
       {% endif %}
     {% endif %}
   announce_vol: >-
@@ -198,31 +208,7 @@ action:
   - choose:
       - conditions:
           - condition: template
-            value_template: >-
-              {{ player_backend == 'home_assistant' and playback_mode == 'media_playback' }}
-        sequence:
-          - action: media_player.play_media
-            target:
-              entity_id: "{{ adhan_entity_id }}"
-            data:
-              media_content_id: "{{ adhan_media_content_id }}"
-              media_content_type: "{{ adhan_media_content_type }}"
-      - conditions:
-          - condition: template
-            value_template: >-
-              {{ player_backend == 'home_assistant' and playback_mode == 'announcement' }}
-        sequence:
-          - action: media_player.play_media
-            target:
-              entity_id: "{{ adhan_entity_id }}"
-            data:
-              media_content_id: "{{ adhan_media_content_id }}"
-              media_content_type: "{{ adhan_media_content_type }}"
-              announce: true
-      - conditions:
-          - condition: template
-            value_template: >-
-              {{ player_backend == 'music_assistant' and playback_mode == 'media_playback' }}
+            value_template: "{{ playback_mode == 'media_playback' }}"
         sequence:
           - action: music_assistant.play_media
             target:
@@ -233,8 +219,7 @@ action:
               enqueue: play
       - conditions:
           - condition: template
-            value_template: >-
-              {{ player_backend == 'music_assistant' and playback_mode == 'announcement' }}
+            value_template: "{{ playback_mode == 'announcement' }}"
         sequence:
           - action: media_source.resolve_media
             data:

--- a/blueprints/fajr_wakeup.yaml
+++ b/blueprints/fajr_wakeup.yaml
@@ -3,7 +3,7 @@ blueprint:
   description: >-
     Gradually turn on bedroom lights and optionally play a soft tone at Fajr or
     at the Mawaqeet Fajr reminder (lead time is set in Mawaqeet options). For
-    full adhan use the adhan blueprint instead. Test with mawaqeet.trigger_event.
+    full adhan use the adhan blueprints instead. Test with mawaqeet.trigger_event.
   domain: automation
   input:
     device_id:

--- a/blueprints/prayer_time_lights.yaml
+++ b/blueprints/prayer_time_lights.yaml
@@ -2,7 +2,7 @@ blueprint:
   name: Prayer time lighting
   description: >-
     Control lights or scenes when a Mawaqeet prayer time occurs. Complements the
-    adhan blueprint (audio). Shuruq, midnight, and last third can be enabled
+    adhan blueprints (audio). Shuruq, midnight, and last third can be enabled
     separately. Test with mawaqeet.trigger_event (trigger_type prayer_time).
   domain: automation
   input:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -120,6 +120,10 @@ async def test_reconfigure_flow(hass: HomeAssistant) -> None:
         new_location[CONF_LATITUDE], new_location[CONF_LONGITUDE]
     )
 
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    assert entry.state == ConfigEntryState.LOADED
+    entry.runtime_data.coordinator.clear_event_sub()
+
 
 async def test_custom_calculation_adjustment(hass: HomeAssistant) -> None:
     """Test custom calculation method shows angle fields in adjustment step."""

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -97,6 +97,7 @@ async def test_reconfigure_flow(hass: HomeAssistant) -> None:
         options={MADHAB: "shafi"},
     )
     entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
 
     result = await entry.start_reconfigure_flow(hass)
     assert result["type"] == FlowResultType.FORM
@@ -120,7 +121,7 @@ async def test_reconfigure_flow(hass: HomeAssistant) -> None:
         new_location[CONF_LATITUDE], new_location[CONF_LONGITUDE]
     )
 
-    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
     assert entry.state == ConfigEntryState.LOADED
     entry.runtime_data.coordinator.clear_event_sub()
 


### PR DESCRIPTION
## Summary

- Align the integration with Home Assistant **2026.3.2+** (runtime data, reconfigure/options flows, diagnostics, quality scale **Gold** with CI coverage).
- Add a **Mawaqeet prayer Lovelace card** (frontend build + Vitest) and brand assets.
- Ship **five automation blueprints**, including split **Adhan (Home Assistant)** and **Adhan (Music Assistant)** blueprints (replaces combined `adhan.yaml`).
- Document blueprints in the README with **My Home Assistant** one-click import badges.

## Test plan

- [ ] CI green on this PR (lint, validate/hassfest, tests with coverage, frontend)
- [ ] Install via HACS or manual copy; add integration and confirm prayer sensors/events update
- [ ] Import each blueprint via README badge or manual URL; create a test automation
- [ ] Lovelace card: add **Mawaqeet Prayer** card and verify timetable / next prayer
- [ ] Music Assistant adhan blueprint on an MA player; HA adhan blueprint on Sonos/Cast (no `ma_*` entities)
- [ ] `mawaqeet.trigger_event` for prayer time and reminder testing