### PR TITLE
Fix adhan blueprints and Lovelace grid resize support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,15 @@ Five automation blueprints ship with this repository. Use the **Import** badges 
 | Other prayers adhan audio (announcement) | Audio for Dhuhr–Ishaa in announcement mode |
 | Announcement volume (Fajr / other) | Music Assistant blueprint only: optional 0–100 |
 
-**Fajr vs other prayers:** Pick separate players and audio files for Fajr and for the rest of the day. Select **multiple** `media_player` entities per window to play adhan on all speakers at once. Use different announcement vs playback clips if you want a short announce at Fajr and full adhan elsewhere.
+**Fajr vs other prayers:** Pick separate players and audio files for Fajr and for the rest of the day. Select **multiple** `media_player` entities per window to play adhan on all speakers at once (one action targets every selected player). Use different announcement vs playback clips if you want a short announce at Fajr and full adhan elsewhere.
+
+**Optional fields:** After re-importing, you only need to fill media and players for your chosen **playback mode**. The other mode’s audio fields can stay at their defaults (empty). Player lists default to empty until you add speakers.
 
 **Home Assistant blueprint:** Uses `media_player.play_media`. Announcement mode sets `announce: true` (works best on Sonos and similar players). Do not select `media_player.ma_*` entities — use the Music Assistant blueprint for those.
 
 **Music Assistant blueprint:** Uses `music_assistant.play_media` and `music_assistant.play_announcement`. Player selectors list only Music Assistant players. For announcements, local files under `/config/www/` (`http://<your-ha>/local/...`) or `http(s)` URLs work reliably; other paths are resolved via `media_source.resolve_media`.
 
-**Migration from older adhan blueprints:** Re-import the Home Assistant or Music Assistant blueprint (badges above), then edit or recreate your automation. Map each former single player to the new multi-select **media player(s)** fields (one entry per speaker). Audio inputs are unchanged.
+**Migration from older adhan blueprints:** Re-import the Home Assistant or Music Assistant blueprint (badges above), then edit or recreate your automation. Map each former single player to the new multi-select **media player(s)** fields (one entry per speaker). If you see *Message malformed* about `repeat.parallel`, you are on an older Music Assistant blueprint — re-import fixes it.
 
 Example (Music Assistant, Fajr announcement):
 

--- a/blueprints/adhan_home_assistant.yaml
+++ b/blueprints/adhan_home_assistant.yaml
@@ -59,6 +59,7 @@ blueprint:
       description: >-
         One or more media_player entities for Fajr (not Music Assistant).
         Adhan plays on all selected speakers at once.
+      default: []
       selector:
         entity:
           multiple: true
@@ -69,6 +70,7 @@ blueprint:
       description: >-
         One or more media_player entities for Dhuhr through Ishaa (not Music
         Assistant). Adhan plays on all selected speakers at once.
+      default: []
       selector:
         entity:
           multiple: true
@@ -76,7 +78,12 @@ blueprint:
             - domain: media_player
     media_fajr_playback:
       name: Fajr adhan audio (playback)
-      description: Adhan audio file for Fajr when using media playback mode.
+      description: >-
+        Adhan audio for Fajr in media playback mode. Leave empty if you only use
+        announcement mode for Fajr.
+      default:
+        media_content_id: ""
+        media_content_type: music
       selector:
         media:
           accept:
@@ -84,7 +91,12 @@ blueprint:
             - music
     media_other_playback:
       name: Other prayers adhan audio (playback)
-      description: Adhan audio for Dhuhr through Ishaa in media playback mode.
+      description: >-
+        Adhan audio for Dhuhr through Ishaa in media playback mode. Leave empty
+        if you only use announcement mode for other prayers.
+      default:
+        media_content_id: ""
+        media_content_type: music
       selector:
         media:
           accept:
@@ -92,7 +104,12 @@ blueprint:
             - music
     media_fajr_announce:
       name: Fajr adhan audio (announcement)
-      description: Adhan audio for Fajr in announcement mode (can differ from playback).
+      description: >-
+        Adhan audio for Fajr in announcement mode (can differ from playback).
+        Leave empty if you only use media playback for Fajr.
+      default:
+        media_content_id: ""
+        media_content_type: music
       selector:
         media:
           accept:
@@ -100,7 +117,12 @@ blueprint:
             - music
     media_other_announce:
       name: Other prayers adhan audio (announcement)
-      description: Adhan audio for Dhuhr through Ishaa in announcement mode.
+      description: >-
+        Adhan audio for Dhuhr through Ishaa in announcement mode. Leave empty if
+        you only use media playback for other prayers.
+      default:
+        media_content_id: ""
+        media_content_type: music
       selector:
         media:
           accept:
@@ -144,29 +166,29 @@ variables:
   adhan_media_content_id: >-
     {% if playback_mode == 'announcement' %}
       {% if current_prayer == 'fajr' %}
-        {{ media_fajr_announce.media_content_id }}
+        {{ media_fajr_announce.media_content_id | default('') }}
       {% else %}
-        {{ media_other_announce.media_content_id }}
+        {{ media_other_announce.media_content_id | default('') }}
       {% endif %}
     {% else %}
       {% if current_prayer == 'fajr' %}
-        {{ media_fajr_playback.media_content_id }}
+        {{ media_fajr_playback.media_content_id | default('') }}
       {% else %}
-        {{ media_other_playback.media_content_id }}
+        {{ media_other_playback.media_content_id | default('') }}
       {% endif %}
     {% endif %}
   adhan_media_content_type: >-
     {% if playback_mode == 'announcement' %}
       {% if current_prayer == 'fajr' %}
-        {{ media_fajr_announce.media_content_type }}
+        {{ media_fajr_announce.media_content_type | default('music') }}
       {% else %}
-        {{ media_other_announce.media_content_type }}
+        {{ media_other_announce.media_content_type | default('music') }}
       {% endif %}
     {% else %}
       {% if current_prayer == 'fajr' %}
-        {{ media_fajr_playback.media_content_type }}
+        {{ media_fajr_playback.media_content_type | default('music') }}
       {% else %}
-        {{ media_other_playback.media_content_type }}
+        {{ media_other_playback.media_content_type | default('music') }}
       {% endif %}
     {% endif %}
 
@@ -183,7 +205,8 @@ action:
     event_data:
       prayer: "{{ current_prayer }}"
   - condition: template
-    value_template: "{{ adhan_entity_ids | length > 0 }}"
+    value_template: >-
+      {{ adhan_entity_ids | length > 0 and adhan_media_content_id | length > 0 }}
   - choose:
       - conditions:
           - condition: template

--- a/blueprints/adhan_music_assistant.yaml
+++ b/blueprints/adhan_music_assistant.yaml
@@ -59,6 +59,7 @@ blueprint:
       description: >-
         One or more Music Assistant media_player entities for Fajr (for example
         media_player.ma_kitchen). Adhan plays on all selected speakers at once.
+      default: []
       selector:
         entity:
           multiple: true
@@ -70,6 +71,7 @@ blueprint:
       description: >-
         One or more Music Assistant media_player entities for Dhuhr through
         Ishaa. Adhan plays on all selected speakers at once.
+      default: []
       selector:
         entity:
           multiple: true
@@ -78,7 +80,12 @@ blueprint:
               integration: music_assistant
     media_fajr_playback:
       name: Fajr adhan audio (playback)
-      description: Adhan audio file for Fajr when using media playback mode.
+      description: >-
+        Adhan audio for Fajr in media playback mode. Leave empty if you only use
+        announcement mode for Fajr.
+      default:
+        media_content_id: ""
+        media_content_type: music
       selector:
         media:
           accept:
@@ -86,7 +93,12 @@ blueprint:
             - music
     media_other_playback:
       name: Other prayers adhan audio (playback)
-      description: Adhan audio for Dhuhr through Ishaa in media playback mode.
+      description: >-
+        Adhan audio for Dhuhr through Ishaa in media playback mode. Leave empty
+        if you only use announcement mode for other prayers.
+      default:
+        media_content_id: ""
+        media_content_type: music
       selector:
         media:
           accept:
@@ -96,7 +108,10 @@ blueprint:
       name: Fajr adhan audio (announcement)
       description: >-
         Adhan audio for Fajr in announcement mode. Prefer files in /config/www
-        or http(s) URLs.
+        or http(s) URLs. Leave empty if you only use media playback for Fajr.
+      default:
+        media_content_id: ""
+        media_content_type: music
       selector:
         media:
           accept:
@@ -106,7 +121,11 @@ blueprint:
       name: Other prayers adhan audio (announcement)
       description: >-
         Adhan audio for Dhuhr through Ishaa in announcement mode. Prefer files
-        in /config/www or http(s) URLs.
+        in /config/www or http(s) URLs. Leave empty if you only use media
+        playback for other prayers.
+      default:
+        media_content_id: ""
+        media_content_type: music
       selector:
         media:
           accept:
@@ -117,6 +136,7 @@ blueprint:
       description: >-
         Optional forced volume (0–100) for Fajr announcements. Leave empty to
         use the player default.
+      default: null
       selector:
         number:
           min: 0
@@ -128,6 +148,7 @@ blueprint:
       description: >-
         Optional forced volume (0–100) for other prayer announcements. Leave
         empty to use the player default.
+      default: null
       selector:
         number:
           min: 0
@@ -167,29 +188,29 @@ variables:
   adhan_media_content_id: >-
     {% if playback_mode == 'announcement' %}
       {% if current_prayer == 'fajr' %}
-        {{ media_fajr_announce.media_content_id }}
+        {{ media_fajr_announce.media_content_id | default('') }}
       {% else %}
-        {{ media_other_announce.media_content_id }}
+        {{ media_other_announce.media_content_id | default('') }}
       {% endif %}
     {% else %}
       {% if current_prayer == 'fajr' %}
-        {{ media_fajr_playback.media_content_id }}
+        {{ media_fajr_playback.media_content_id | default('') }}
       {% else %}
-        {{ media_other_playback.media_content_id }}
+        {{ media_other_playback.media_content_id | default('') }}
       {% endif %}
     {% endif %}
   adhan_media_content_type: >-
     {% if playback_mode == 'announcement' %}
       {% if current_prayer == 'fajr' %}
-        {{ media_fajr_announce.media_content_type }}
+        {{ media_fajr_announce.media_content_type | default('music') }}
       {% else %}
-        {{ media_other_announce.media_content_type }}
+        {{ media_other_announce.media_content_type | default('music') }}
       {% endif %}
     {% else %}
       {% if current_prayer == 'fajr' %}
-        {{ media_fajr_playback.media_content_type }}
+        {{ media_fajr_playback.media_content_type | default('music') }}
       {% else %}
-        {{ media_other_playback.media_content_type }}
+        {{ media_other_playback.media_content_type | default('music') }}
       {% endif %}
     {% endif %}
   announce_vol: >-
@@ -214,23 +235,20 @@ action:
     event_data:
       prayer: "{{ current_prayer }}"
   - condition: template
-    value_template: "{{ adhan_entity_ids | length > 0 }}"
+    value_template: >-
+      {{ adhan_entity_ids | length > 0 and adhan_media_content_id | length > 0 }}
   - choose:
       - conditions:
           - condition: template
             value_template: "{{ playback_mode == 'media_playback' }}"
         sequence:
-          - repeat:
-              for_each: "{{ adhan_entity_ids }}"
-              parallel: true
-              sequence:
-                - action: music_assistant.play_media
-                  target:
-                    entity_id: "{{ repeat.item }}"
-                  data:
-                    media_id: "{{ adhan_media_content_id }}"
-                    media_type: "{{ adhan_media_content_type }}"
-                    enqueue: play
+          - action: music_assistant.play_media
+            target:
+              entity_id: "{{ adhan_entity_ids }}"
+            data:
+              media_id: "{{ adhan_media_content_id }}"
+              media_type: "{{ adhan_media_content_type }}"
+              enqueue: play
       - conditions:
           - condition: template
             value_template: "{{ playback_mode == 'announcement' }}"
@@ -245,36 +263,28 @@ action:
                   - condition: template
                     value_template: "{{ announce_vol is number }}"
                 sequence:
-                  - repeat:
-                      for_each: "{{ adhan_entity_ids }}"
-                      parallel: true
-                      sequence:
-                        - action: music_assistant.play_announcement
-                          target:
-                            entity_id: "{{ repeat.item }}"
-                          data:
-                            url: >-
-                              {% if adhan_media_content_id is match('https?://.*') %}
-                                {{ adhan_media_content_id }}
-                              {% else %}
-                                {{ resolved_adhan.url }}
-                              {% endif %}
-                            announce_volume: "{{ announce_vol }}"
+                  - action: music_assistant.play_announcement
+                    target:
+                      entity_id: "{{ adhan_entity_ids }}"
+                    data:
+                      url: >-
+                        {% if adhan_media_content_id is match('https?://.*') %}
+                          {{ adhan_media_content_id }}
+                        {% else %}
+                          {{ resolved_adhan.url }}
+                        {% endif %}
+                      announce_volume: "{{ announce_vol }}"
               - conditions: []
                 sequence:
-                  - repeat:
-                      for_each: "{{ adhan_entity_ids }}"
-                      parallel: true
-                      sequence:
-                        - action: music_assistant.play_announcement
-                          target:
-                            entity_id: "{{ repeat.item }}"
-                          data:
-                            url: >-
-                              {% if adhan_media_content_id is match('https?://.*') %}
-                                {{ adhan_media_content_id }}
-                              {% else %}
-                                {{ resolved_adhan.url }}
-                              {% endif %}
+                  - action: music_assistant.play_announcement
+                    target:
+                      entity_id: "{{ adhan_entity_ids }}"
+                    data:
+                      url: >-
+                        {% if adhan_media_content_id is match('https?://.*') %}
+                          {{ adhan_media_content_id }}
+                        {% else %}
+                          {{ resolved_adhan.url }}
+                        {% endif %}
 
 mode: single

--- a/custom_components/mawaqeet/frontend/src/grid-options.test.ts
+++ b/custom_components/mawaqeet/frontend/src/grid-options.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { gridOptionsForLayout } from "./grid-options";
+import type { CardLayout } from "./types";
+
+describe("gridOptionsForLayout", () => {
+  it("returns compact defaults for next layout", () => {
+    expect(gridOptionsForLayout("next")).toEqual({
+      columns: 6,
+      rows: 2,
+      min_rows: 2,
+      min_columns: 3,
+    });
+  });
+
+  it("returns full-width auto height for horizontal and combined", () => {
+    const expected = {
+      columns: 12,
+      rows: "auto",
+      min_rows: 2,
+      min_columns: 6,
+    };
+    expect(gridOptionsForLayout("horizontal")).toEqual(expected);
+    expect(gridOptionsForLayout("combined")).toEqual(expected);
+  });
+
+  it("returns fixed rows for timeline", () => {
+    expect(gridOptionsForLayout("timeline")).toEqual({
+      columns: 12,
+      rows: 3,
+      min_rows: 2,
+      max_rows: 4,
+    });
+  });
+
+  it("returns tall auto rows for vertical and agenda", () => {
+    const expected = {
+      columns: 6,
+      rows: "auto",
+      min_rows: 4,
+      min_columns: 3,
+    };
+    expect(gridOptionsForLayout("vertical")).toEqual(expected);
+    expect(gridOptionsForLayout("agenda")).toEqual(expected);
+  });
+
+  it("falls back to next layout for unknown values", () => {
+    expect(gridOptionsForLayout("unknown" as CardLayout)).toEqual(
+      gridOptionsForLayout("next"),
+    );
+  });
+});

--- a/custom_components/mawaqeet/frontend/src/grid-options.ts
+++ b/custom_components/mawaqeet/frontend/src/grid-options.ts
@@ -1,0 +1,38 @@
+import type { CardLayout, LovelaceGridOptions } from "./types";
+
+/** Default grid sizing per layout for Sections dashboards. */
+export function gridOptionsForLayout(layout: CardLayout): LovelaceGridOptions {
+  switch (layout) {
+    case "horizontal":
+    case "combined":
+      return {
+        columns: 12,
+        rows: "auto",
+        min_rows: 2,
+        min_columns: 6,
+      };
+    case "timeline":
+      return {
+        columns: 12,
+        rows: 3,
+        min_rows: 2,
+        max_rows: 4,
+      };
+    case "vertical":
+    case "agenda":
+      return {
+        columns: 6,
+        rows: "auto",
+        min_rows: 4,
+        min_columns: 3,
+      };
+    case "next":
+    default:
+      return {
+        columns: 6,
+        rows: 2,
+        min_rows: 2,
+        min_columns: 3,
+      };
+  }
+}

--- a/custom_components/mawaqeet/frontend/src/mawaqeet-prayer-card.test.ts
+++ b/custom_components/mawaqeet/frontend/src/mawaqeet-prayer-card.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { gridOptionsForLayout } from "./grid-options";
+import { MawaqeetPrayerCard } from "./mawaqeet-prayer-card";
+import type { CardLayout, MawaqeetCardConfig } from "./types";
+
+function cardWithLayout(layout: CardLayout): MawaqeetPrayerCard {
+  const card = Object.create(
+    MawaqeetPrayerCard.prototype,
+  ) as MawaqeetPrayerCard;
+  const config: MawaqeetCardConfig = {
+    type: "custom:mawaqeet-prayer-card",
+    device: "device-1",
+    layout,
+  };
+  Object.defineProperty(card, "_config", { value: config, writable: true });
+  return card;
+}
+
+describe("MawaqeetPrayerCard sizing", () => {
+  it("getGridOptions matches gridOptionsForLayout per layout", () => {
+    const layouts: CardLayout[] = [
+      "next",
+      "horizontal",
+      "vertical",
+      "combined",
+      "timeline",
+      "agenda",
+    ];
+    for (const layout of layouts) {
+      const card = cardWithLayout(layout);
+      expect(card.getGridOptions()).toEqual(gridOptionsForLayout(layout));
+    }
+  });
+
+  it("getCardSize returns legacy masonry heights", () => {
+    expect(cardWithLayout("next").getCardSize()).toBe(2);
+    expect(cardWithLayout("horizontal").getCardSize()).toBe(2);
+    expect(cardWithLayout("combined").getCardSize()).toBe(2);
+    expect(cardWithLayout("vertical").getCardSize()).toBe(4);
+    expect(cardWithLayout("agenda").getCardSize()).toBe(4);
+    expect(cardWithLayout("timeline").getCardSize()).toBe(3);
+  });
+});

--- a/custom_components/mawaqeet/frontend/src/mawaqeet-prayer-card.ts
+++ b/custom_components/mawaqeet/frontend/src/mawaqeet-prayer-card.ts
@@ -1,9 +1,14 @@
 import { LitElement, html, type CSSResultGroup, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { resolvePrayerEntities } from "./entity-resolver";
+import { gridOptionsForLayout } from "./grid-options";
 import { renderError, renderLayout } from "./layouts/render";
 import { cardStyles } from "./styles";
-import type { HomeAssistant, MawaqeetCardConfig } from "./types";
+import type {
+  HomeAssistant,
+  LovelaceGridOptions,
+  MawaqeetCardConfig,
+} from "./types";
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -60,6 +65,11 @@ export class MawaqeetPrayerCard extends LitElement {
       default:
         return 2;
     }
+  }
+
+  public getGridOptions(): LovelaceGridOptions {
+    const layout = this._config?.layout ?? "next";
+    return gridOptionsForLayout(layout);
   }
 
   public static async getConfigElement(): Promise<HTMLElement> {
@@ -228,10 +238,12 @@ const EDITOR_LABELS: Record<string, string> = {
   show_device_name: "Show location name",
 };
 
-window.customCards = window.customCards || [];
-window.customCards.push({
-  type: "mawaqeet-prayer-card",
-  name: "Mawaqeet Prayer",
-  description: "Prayer times from a Mawaqeet location device",
-  preview: true,
-});
+if (typeof window !== "undefined") {
+  window.customCards = window.customCards || [];
+  window.customCards.push({
+    type: "mawaqeet-prayer-card",
+    name: "Mawaqeet Prayer",
+    description: "Prayer times from a Mawaqeet location device",
+    preview: true,
+  });
+}

--- a/custom_components/mawaqeet/frontend/src/styles.ts
+++ b/custom_components/mawaqeet/frontend/src/styles.ts
@@ -3,11 +3,15 @@ import { css } from "lit";
 export const cardStyles = css`
   :host {
     display: block;
+    height: 100%;
   }
 
   ha-card {
+    height: 100%;
     overflow: hidden;
     padding: 16px;
+    display: flex;
+    flex-direction: column;
   }
 
   .header {

--- a/custom_components/mawaqeet/frontend/src/types.ts
+++ b/custom_components/mawaqeet/frontend/src/types.ts
@@ -44,6 +44,16 @@ export type CardLayout =
 
 export type TimeFormat = "system" | "24" | "12";
 
+/** Sections-view grid sizing (Home Assistant LovelaceGridOptions). */
+export interface LovelaceGridOptions {
+  columns?: number | "full";
+  rows?: number | "auto";
+  max_columns?: number;
+  min_columns?: number;
+  min_rows?: number;
+  max_rows?: number;
+}
+
 export interface MawaqeetCardConfig {
   type: string;
   device?: string;

--- a/custom_components/mawaqeet/www/mawaqeet-prayer-card.js
+++ b/custom_components/mawaqeet/www/mawaqeet-prayer-card.js
@@ -3,7 +3,7 @@
  * Copyright 2019 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const I = globalThis, G = I.ShadowRoot && (I.ShadyCSS === void 0 || I.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, Q = Symbol(), oe = /* @__PURE__ */ new WeakMap();
+const I = globalThis, J = I.ShadowRoot && (I.ShadyCSS === void 0 || I.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, Q = Symbol(), oe = /* @__PURE__ */ new WeakMap();
 let ye = class {
   constructor(e, t, i) {
     if (this._$cssResult$ = !0, i !== Q) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
@@ -12,7 +12,7 @@ let ye = class {
   get styleSheet() {
     let e = this.o;
     const t = this.t;
-    if (G && e === void 0) {
+    if (J && e === void 0) {
       const i = t !== void 0 && t.length === 1;
       i && (e = oe.get(t)), e === void 0 && ((this.o = e = new CSSStyleSheet()).replaceSync(this.cssText), i && oe.set(t, e));
     }
@@ -22,7 +22,7 @@ let ye = class {
     return this.cssText;
   }
 };
-const ke = (s) => new ye(typeof s == "string" ? s : s + "", void 0, Q), Oe = (s, ...e) => {
+const Oe = (s) => new ye(typeof s == "string" ? s : s + "", void 0, Q), ke = (s, ...e) => {
   const t = s.length === 1 ? s[0] : e.reduce((i, r, n) => i + ((o) => {
     if (o._$cssResult$ === !0) return o.cssText;
     if (typeof o == "number") return o;
@@ -30,22 +30,22 @@ const ke = (s) => new ye(typeof s == "string" ? s : s + "", void 0, Q), Oe = (s,
   })(r) + s[n + 1], s[0]);
   return new ye(t, s, Q);
 }, Ue = (s, e) => {
-  if (G) s.adoptedStyleSheets = e.map((t) => t instanceof CSSStyleSheet ? t : t.styleSheet);
+  if (J) s.adoptedStyleSheets = e.map((t) => t instanceof CSSStyleSheet ? t : t.styleSheet);
   else for (const t of e) {
     const i = document.createElement("style"), r = I.litNonce;
     r !== void 0 && i.setAttribute("nonce", r), i.textContent = t.cssText, s.appendChild(i);
   }
-}, ae = G ? (s) => s : (s) => s instanceof CSSStyleSheet ? ((e) => {
+}, ae = J ? (s) => s : (s) => s instanceof CSSStyleSheet ? ((e) => {
   let t = "";
   for (const i of e.cssRules) t += i.cssText;
-  return ke(t);
+  return Oe(t);
 })(s) : s;
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const { is: Ne, defineProperty: Me, getOwnPropertyDescriptor: Re, getOwnPropertyNames: ze, getOwnPropertySymbols: De, getPrototypeOf: He } = Object, $ = globalThis, le = $.trustedTypes, qe = le ? le.emptyScript : "", F = $.reactiveElementPolyfillSupport, O = (s, e) => s, L = { toAttribute(s, e) {
+const { is: Ne, defineProperty: Me, getOwnPropertyDescriptor: Re, getOwnPropertyNames: ze, getOwnPropertySymbols: De, getPrototypeOf: He } = Object, $ = globalThis, le = $.trustedTypes, qe = le ? le.emptyScript : "", F = $.reactiveElementPolyfillSupport, k = (s, e) => s, L = { toAttribute(s, e) {
   switch (e) {
     case Boolean:
       s = s ? qe : null;
@@ -103,13 +103,13 @@ let x = class extends HTMLElement {
     return this.elementProperties.get(e) ?? ce;
   }
   static _$Ei() {
-    if (this.hasOwnProperty(O("elementProperties"))) return;
+    if (this.hasOwnProperty(k("elementProperties"))) return;
     const e = He(this);
     e.finalize(), e.l !== void 0 && (this.l = [...e.l]), this.elementProperties = new Map(e.elementProperties);
   }
   static finalize() {
-    if (this.hasOwnProperty(O("finalized"))) return;
-    if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(O("properties"))) {
+    if (this.hasOwnProperty(k("finalized"))) return;
+    if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(k("properties"))) {
       const t = this.properties, i = [...ze(t), ...De(t)];
       for (const r of i) this.createProperty(r, t[r]);
     }
@@ -278,28 +278,28 @@ let x = class extends HTMLElement {
   firstUpdated(e) {
   }
 };
-x.elementStyles = [], x.shadowRootOptions = { mode: "open" }, x[O("elementProperties")] = /* @__PURE__ */ new Map(), x[O("finalized")] = /* @__PURE__ */ new Map(), F == null || F({ ReactiveElement: x }), ($.reactiveElementVersions ?? ($.reactiveElementVersions = [])).push("2.1.2");
+x.elementStyles = [], x.shadowRootOptions = { mode: "open" }, x[k("elementProperties")] = /* @__PURE__ */ new Map(), x[k("finalized")] = /* @__PURE__ */ new Map(), F == null || F({ ReactiveElement: x }), ($.reactiveElementVersions ?? ($.reactiveElementVersions = [])).push("2.1.2");
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const U = globalThis, he = (s) => s, B = U.trustedTypes, de = B ? B.createPolicy("lit-html", { createHTML: (s) => s }) : void 0, be = "$lit$", _ = `lit$${Math.random().toFixed(9).slice(2)}$`, we = "?" + _, je = `<${we}>`, b = document, N = () => b.createComment(""), M = (s) => s === null || typeof s != "object" && typeof s != "function", te = Array.isArray, Ie = (s) => te(s) || typeof (s == null ? void 0 : s[Symbol.iterator]) == "function", X = `[ 	
-\f\r]`, k = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, ue = /-->/g, pe = />/g, v = RegExp(`>|${X}(?:([^\\s"'>=/]+)(${X}*=${X}*(?:[^ 	
-\f\r"'\`<>=]|("|')|))|$)`, "g"), fe = /'/g, me = /"/g, Ae = /^(?:script|style|textarea|title)$/i, Le = (s) => (e, ...t) => ({ _$litType$: s, strings: e, values: t }), p = Le(1), S = Symbol.for("lit-noChange"), u = Symbol.for("lit-nothing"), _e = /* @__PURE__ */ new WeakMap(), g = b.createTreeWalker(b, 129);
+const U = globalThis, he = (s) => s, B = U.trustedTypes, de = B ? B.createPolicy("lit-html", { createHTML: (s) => s }) : void 0, we = "$lit$", _ = `lit$${Math.random().toFixed(9).slice(2)}$`, be = "?" + _, je = `<${be}>`, w = document, N = () => w.createComment(""), M = (s) => s === null || typeof s != "object" && typeof s != "function", te = Array.isArray, Ie = (s) => te(s) || typeof (s == null ? void 0 : s[Symbol.iterator]) == "function", X = `[ 	
+\f\r]`, O = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, ue = /-->/g, pe = />/g, v = RegExp(`>|${X}(?:([^\\s"'>=/]+)(${X}*=${X}*(?:[^ 	
+\f\r"'\`<>=]|("|')|))|$)`, "g"), me = /'/g, fe = /"/g, Ae = /^(?:script|style|textarea|title)$/i, Le = (s) => (e, ...t) => ({ _$litType$: s, strings: e, values: t }), p = Le(1), S = Symbol.for("lit-noChange"), u = Symbol.for("lit-nothing"), _e = /* @__PURE__ */ new WeakMap(), g = w.createTreeWalker(w, 129);
 function xe(s, e) {
   if (!te(s) || !s.hasOwnProperty("raw")) throw Error("invalid template strings array");
   return de !== void 0 ? de.createHTML(e) : e;
 }
 const Be = (s, e) => {
   const t = s.length - 1, i = [];
-  let r, n = e === 2 ? "<svg>" : e === 3 ? "<math>" : "", o = k;
+  let r, n = e === 2 ? "<svg>" : e === 3 ? "<math>" : "", o = O;
   for (let a = 0; a < t; a++) {
     const l = s[a];
-    let c, d, h = -1, f = 0;
-    for (; f < l.length && (o.lastIndex = f, d = o.exec(l), d !== null); ) f = o.lastIndex, o === k ? d[1] === "!--" ? o = ue : d[1] !== void 0 ? o = pe : d[2] !== void 0 ? (Ae.test(d[2]) && (r = RegExp("</" + d[2], "g")), o = v) : d[3] !== void 0 && (o = v) : o === v ? d[0] === ">" ? (o = r ?? k, h = -1) : d[1] === void 0 ? h = -2 : (h = o.lastIndex - d[2].length, c = d[1], o = d[3] === void 0 ? v : d[3] === '"' ? me : fe) : o === me || o === fe ? o = v : o === ue || o === pe ? o = k : (o = v, r = void 0);
-    const m = o === v && s[a + 1].startsWith("/>") ? " " : "";
-    n += o === k ? l + je : h >= 0 ? (i.push(c), l.slice(0, h) + be + l.slice(h) + _ + m) : l + _ + (h === -2 ? a : m);
+    let c, d, h = -1, m = 0;
+    for (; m < l.length && (o.lastIndex = m, d = o.exec(l), d !== null); ) m = o.lastIndex, o === O ? d[1] === "!--" ? o = ue : d[1] !== void 0 ? o = pe : d[2] !== void 0 ? (Ae.test(d[2]) && (r = RegExp("</" + d[2], "g")), o = v) : d[3] !== void 0 && (o = v) : o === v ? d[0] === ">" ? (o = r ?? O, h = -1) : d[1] === void 0 ? h = -2 : (h = o.lastIndex - d[2].length, c = d[1], o = d[3] === void 0 ? v : d[3] === '"' ? fe : me) : o === fe || o === me ? o = v : o === ue || o === pe ? o = O : (o = v, r = void 0);
+    const f = o === v && s[a + 1].startsWith("/>") ? " " : "";
+    n += o === O ? l + je : h >= 0 ? (i.push(c), l.slice(0, h) + we + l.slice(h) + _ + f) : l + _ + (h === -2 ? a : f);
   }
   return [xe(s, n + (s[t] || "<?>") + (e === 2 ? "</svg>" : e === 3 ? "</math>" : "")), i];
 };
@@ -315,19 +315,19 @@ class R {
     }
     for (; (r = g.nextNode()) !== null && l.length < a; ) {
       if (r.nodeType === 1) {
-        if (r.hasAttributes()) for (const h of r.getAttributeNames()) if (h.endsWith(be)) {
-          const f = d[o++], m = r.getAttribute(h).split(_), A = /([.?@])?(.*)/.exec(f);
-          l.push({ type: 1, index: n, name: A[2], strings: m, ctor: A[1] === "." ? We : A[1] === "?" ? Ke : A[1] === "@" ? Ye : K }), r.removeAttribute(h);
+        if (r.hasAttributes()) for (const h of r.getAttributeNames()) if (h.endsWith(we)) {
+          const m = d[o++], f = r.getAttribute(h).split(_), A = /([.?@])?(.*)/.exec(m);
+          l.push({ type: 1, index: n, name: A[2], strings: f, ctor: A[1] === "." ? We : A[1] === "?" ? Ke : A[1] === "@" ? Ye : K }), r.removeAttribute(h);
         } else h.startsWith(_) && (l.push({ type: 6, index: n }), r.removeAttribute(h));
         if (Ae.test(r.tagName)) {
-          const h = r.textContent.split(_), f = h.length - 1;
-          if (f > 0) {
+          const h = r.textContent.split(_), m = h.length - 1;
+          if (m > 0) {
             r.textContent = B ? B.emptyScript : "";
-            for (let m = 0; m < f; m++) r.append(h[m], N()), g.nextNode(), l.push({ type: 2, index: ++n });
-            r.append(h[f], N());
+            for (let f = 0; f < m; f++) r.append(h[f], N()), g.nextNode(), l.push({ type: 2, index: ++n });
+            r.append(h[m], N());
           }
         }
-      } else if (r.nodeType === 8) if (r.data === we) l.push({ type: 2, index: n });
+      } else if (r.nodeType === 8) if (r.data === be) l.push({ type: 2, index: n });
       else {
         let h = -1;
         for (; (h = r.data.indexOf(_, h + 1)) !== -1; ) l.push({ type: 7, index: n }), h += _.length - 1;
@@ -336,7 +336,7 @@ class R {
     }
   }
   static createElement(e, t) {
-    const i = b.createElement("template");
+    const i = w.createElement("template");
     return i.innerHTML = e, i;
   }
 }
@@ -358,7 +358,7 @@ class Ve {
     return this._$AM._$AU;
   }
   u(e) {
-    const { el: { content: t }, parts: i } = this._$AD, r = ((e == null ? void 0 : e.creationScope) ?? b).importNode(t, !0);
+    const { el: { content: t }, parts: i } = this._$AD, r = ((e == null ? void 0 : e.creationScope) ?? w).importNode(t, !0);
     g.currentNode = r;
     let n = g.nextNode(), o = 0, a = 0, l = i[0];
     for (; l !== void 0; ) {
@@ -368,7 +368,7 @@ class Ve {
       }
       o !== (l == null ? void 0 : l.index) && (n = g.nextNode(), o++);
     }
-    return g.currentNode = b, r;
+    return g.currentNode = w, r;
   }
   p(e) {
     let t = 0;
@@ -404,7 +404,7 @@ class z {
     this._$AH !== e && (this._$AR(), this._$AH = this.O(e));
   }
   _(e) {
-    this._$AH !== u && M(this._$AH) ? this._$AA.nextSibling.data = e : this.T(b.createTextNode(e)), this._$AH = e;
+    this._$AH !== u && M(this._$AH) ? this._$AA.nextSibling.data = e : this.T(w.createTextNode(e)), this._$AH = e;
   }
   $(e) {
     var n;
@@ -548,8 +548,8 @@ class E extends x {
 }
 var ge;
 E._$litElement$ = !0, E.finalized = !0, (ge = y.litElementHydrateSupport) == null || ge.call(y, { LitElement: E });
-const J = y.litElementPolyfillSupport;
-J == null || J({ LitElement: E });
+const G = y.litElementPolyfillSupport;
+G == null || G({ LitElement: E });
 (y.litElementVersions ?? (y.litElementVersions = [])).push("4.2.2");
 /**
  * @license
@@ -566,7 +566,7 @@ const Ee = (s) => (e, t) => {
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const Ze = { attribute: !0, type: String, converter: L, reflect: !1, hasChanged: ee }, Je = (s = Ze, e, t) => {
+const Ze = { attribute: !0, type: String, converter: L, reflect: !1, hasChanged: ee }, Ge = (s = Ze, e, t) => {
   const { kind: i, metadata: r } = t;
   let n = globalThis.litPropertyMetadata.get(r);
   if (n === void 0 && globalThis.litPropertyMetadata.set(r, n = /* @__PURE__ */ new Map()), i === "setter" && ((s = Object.create(s)).wrapped = !0), n.set(t.name, s), i === "accessor") {
@@ -588,7 +588,7 @@ const Ze = { attribute: !0, type: String, converter: L, reflect: !1, hasChanged:
   throw Error("Unsupported decorator location: " + i);
 };
 function ie(s) {
-  return (e, t) => typeof t == "object" ? Je(s, e, t) : ((i, r, n) => {
+  return (e, t) => typeof t == "object" ? Ge(s, e, t) : ((i, r, n) => {
     const o = r.hasOwnProperty(n);
     return r.constructor.createProperty(n, i), o ? Object.getOwnPropertyDescriptor(r, n) : void 0;
   })(s, e, t);
@@ -601,7 +601,7 @@ function ie(s) {
 function se(s) {
   return ie({ ...s, state: !0, attribute: !1 });
 }
-const Ge = [
+const Je = [
   "fajr",
   "dhuhr",
   "asr",
@@ -627,7 +627,7 @@ const Ge = [
   "ishaa_offset"
 ]);
 function Se(s) {
-  return s ? ["fajr", Qe, "dhuhr", "asr", "maghrib", "ishaa"] : [...Ge];
+  return s ? ["fajr", Qe, "dhuhr", "asr", "maghrib", "ishaa"] : [...Je];
 }
 function it(s, e) {
   return et.has(s) || tt.has(s) ? !1 : Se(e).includes(s);
@@ -736,6 +736,41 @@ function ct(s, e) {
   const t = (i = s.devices) == null ? void 0 : i[e];
   return t ? t.name_by_user || t.name || e : "";
 }
+function ht(s) {
+  switch (s) {
+    case "horizontal":
+    case "combined":
+      return {
+        columns: 12,
+        rows: "auto",
+        min_rows: 2,
+        min_columns: 6
+      };
+    case "timeline":
+      return {
+        columns: 12,
+        rows: 3,
+        min_rows: 2,
+        max_rows: 4
+      };
+    case "vertical":
+    case "agenda":
+      return {
+        columns: 6,
+        rows: "auto",
+        min_rows: 4,
+        min_columns: 3
+      };
+    case "next":
+    default:
+      return {
+        columns: 6,
+        rows: 2,
+        min_rows: 2,
+        min_columns: 3
+      };
+  }
+}
 function D(s, e) {
   return e.time_format ?? "system";
 }
@@ -760,7 +795,7 @@ function Ce(s, e, t, i, r) {
   const n = Y(t, i);
   if (!n)
     return V("No prayer times available.");
-  const { prayer: o, following: a, isTomorrow: l } = n, c = D(s, e), d = re(o.at, i, l), h = P(o.at, s, c), f = a && p`Following: ${a.label} at ${P(a.at, s, c)}`;
+  const { prayer: o, following: a, isTomorrow: l } = n, c = D(s, e), d = re(o.at, i, l), h = P(o.at, s, c), m = a && p`Following: ${a.label} at ${P(a.at, s, c)}`;
   return p`
     ${H(s, e)}
     <div
@@ -773,19 +808,19 @@ function Ce(s, e, t, i, r) {
       <div class="prayer-name">${o.label}</div>
       <div class="countdown">${d} · ${h}</div>
       ${l ? p`<div class="following">Tomorrow</div>` : u}
-      ${f ? p`<div class="following">${f}</div>` : u}
+      ${m ? p`<div class="following">${m}</div>` : u}
     </div>
   `;
 }
-function ht(s, e, t, i, r) {
+function dt(s, e, t, i, r) {
   const n = Y(t, i), o = n == null ? void 0 : n.prayer.entity_id, a = D(s, e), l = e.show_relative !== !1;
   return p`
     ${H(s, e)}
     ${t.map((c) => {
-    const d = c.entity_id === o, h = e.show_passed_style !== !1 && c.at.getTime() < i.getTime(), f = ["row", d ? "next" : "", h ? "passed strike" : ""].filter(Boolean).join(" ");
+    const d = c.entity_id === o, h = e.show_passed_style !== !1 && c.at.getTime() < i.getTime(), m = ["row", d ? "next" : "", h ? "passed strike" : ""].filter(Boolean).join(" ");
     return p`
         <div
-          class=${f}
+          class=${m}
           @click=${j(c.entity_id, r)}
           role="button"
           tabindex="0"
@@ -809,10 +844,10 @@ function Pe(s, e, t, i, r) {
     ${H(s, e)}
     <div class="horizontal">
       ${t.map((c) => {
-    const d = c.entity_id === o, h = e.show_passed_style !== !1 && c.at.getTime() < i.getTime(), f = ["chip", d ? "next" : "", h ? "passed" : ""].filter(Boolean).join(" ");
+    const d = c.entity_id === o, h = e.show_passed_style !== !1 && c.at.getTime() < i.getTime(), m = ["chip", d ? "next" : "", h ? "passed" : ""].filter(Boolean).join(" ");
     return p`
           <div
-            class=${f}
+            class=${m}
             @click=${j(c.entity_id, r)}
             role="button"
             tabindex="0"
@@ -829,7 +864,7 @@ function Pe(s, e, t, i, r) {
     </div>
   `;
 }
-function dt(s, e, t, i, r) {
+function ut(s, e, t, i, r) {
   return p`
     ${Ce(s, { ...e, show_device_name: !1 }, t, i, r)}
     <hr class="divider" />
@@ -842,22 +877,22 @@ function dt(s, e, t, i, r) {
   )}
   `;
 }
-function ut(s, e, t, i, r) {
-  const n = Y(t, i), o = n == null ? void 0 : n.prayer.entity_id, a = t.filter((h) => h.at.getTime() > i.getTime()), l = t.filter((h) => h.at.getTime() <= i.getTime()), c = D(s, e), d = (h, f) => p`
+function pt(s, e, t, i, r) {
+  const n = Y(t, i), o = n == null ? void 0 : n.prayer.entity_id, a = t.filter((h) => h.at.getTime() > i.getTime()), l = t.filter((h) => h.at.getTime() <= i.getTime()), c = D(s, e), d = (h, m) => p`
     <div class="section-title">${h}</div>
-    ${f.map((m) => {
-    const A = m.entity_id === o, ne = l.includes(m), Te = ["row", A ? "next" : "", ne ? "passed" : ""].filter(Boolean).join(" ");
+    ${m.map((f) => {
+    const A = f.entity_id === o, ne = l.includes(f), Te = ["row", A ? "next" : "", ne ? "passed" : ""].filter(Boolean).join(" ");
     return p`
         <div
           class=${Te}
-          @click=${j(m.entity_id, r)}
+          @click=${j(f.entity_id, r)}
           role="button"
           tabindex="0"
         >
           ${ne ? p`<span class="agenda-check">✓</span>` : u}
-          ${q(m.icon)}
-          <span class="name">${m.label}</span>
-          <span class="times">${P(m.at, s, c)}</span>
+          ${q(f.icon)}
+          <span class="name">${f.label}</span>
+          <span class="times">${P(f.at, s, c)}</span>
         </div>
       `;
   })}
@@ -868,7 +903,7 @@ function ut(s, e, t, i, r) {
     ${a.length ? d("Upcoming", a) : d("Upcoming", t)}
   `;
 }
-function pt(s, e, t, i, r) {
+function mt(s, e, t, i, r) {
   if (t.length < 2)
     return V("Not enough prayer times for timeline.");
   const n = t[0].at.getTime(), a = t[t.length - 1].at.getTime() - n || 1, l = Math.min(100, Math.max(0, (i.getTime() - n) / a * 100)), c = D(s, e);
@@ -901,24 +936,28 @@ function ft(s, e, t, i, r) {
     case "horizontal":
       return Pe(s, e, t, i, r);
     case "vertical":
-      return ht(s, e, t, i, r);
-    case "combined":
       return dt(s, e, t, i, r);
-    case "timeline":
-      return pt(s, e, t, i, r);
-    case "agenda":
+    case "combined":
       return ut(s, e, t, i, r);
+    case "timeline":
+      return mt(s, e, t, i, r);
+    case "agenda":
+      return pt(s, e, t, i, r);
   }
   return Ce(s, e, t, i, r);
 }
-const mt = Oe`
+const _t = ke`
   :host {
     display: block;
+    height: 100%;
   }
 
   ha-card {
+    height: 100%;
     overflow: hidden;
     padding: 16px;
+    display: flex;
+    flex-direction: column;
   }
 
   .header {
@@ -1109,10 +1148,10 @@ const mt = Oe`
     margin-inline-end: 4px;
   }
 `;
-var _t = Object.defineProperty, $t = Object.getOwnPropertyDescriptor, w = (s, e, t, i) => {
-  for (var r = i > 1 ? void 0 : i ? $t(e, t) : e, n = s.length - 1, o; n >= 0; n--)
+var $t = Object.defineProperty, vt = Object.getOwnPropertyDescriptor, b = (s, e, t, i) => {
+  for (var r = i > 1 ? void 0 : i ? vt(e, t) : e, n = s.length - 1, o; n >= 0; n--)
     (o = s[n]) && (r = (i ? o(e, t, r) : o(r)) || r);
-  return i && r && _t(e, t, r), r;
+  return i && r && $t(e, t, r), r;
 };
 let T = class extends E {
   constructor() {
@@ -1146,6 +1185,11 @@ let T = class extends E {
       default:
         return 2;
     }
+  }
+  getGridOptions() {
+    var e;
+    const s = ((e = this._config) == null ? void 0 : e.layout) ?? "next";
+    return ht(s);
   }
   static async getConfigElement() {
     return document.createElement("mawaqeet-prayer-card-editor");
@@ -1196,20 +1240,20 @@ let T = class extends E {
     this.dispatchEvent(e);
   }
 };
-T.styles = mt;
-w([
+T.styles = _t;
+b([
   ie({ attribute: !1 })
 ], T.prototype, "hass", 2);
-w([
+b([
   se()
 ], T.prototype, "_config", 2);
-w([
+b([
   se()
 ], T.prototype, "_now", 2);
-T = w([
+T = b([
   Ee("mawaqeet-prayer-card")
 ], T);
-const vt = [
+const gt = [
   {
     name: "device",
     required: !0,
@@ -1258,8 +1302,8 @@ let W = class extends E {
       <ha-form
         .hass=${this.hass}
         .data=${this._config}
-        .schema=${vt}
-        .computeLabel=${(s) => gt[s.name] ?? s.name}
+        .schema=${gt}
+        .computeLabel=${(s) => yt[s.name] ?? s.name}
         @value-changed=${this._changed}
       ></ha-form>
     `;
@@ -1276,16 +1320,16 @@ let W = class extends E {
     this.dispatchEvent(t);
   }
 };
-w([
+b([
   ie({ attribute: !1 })
 ], W.prototype, "hass", 2);
-w([
+b([
   se()
 ], W.prototype, "_config", 2);
-W = w([
+W = b([
   Ee("mawaqeet-prayer-card-editor")
 ], W);
-const gt = {
+const yt = {
   device: "Mawaqeet location",
   layout: "Layout",
   show_shuruq: "Show Shuruq (sunrise)",
@@ -1294,13 +1338,12 @@ const gt = {
   show_relative: "Show relative times",
   show_device_name: "Show location name"
 };
-window.customCards = window.customCards || [];
-window.customCards.push({
+typeof window < "u" && (window.customCards = window.customCards || [], window.customCards.push({
   type: "mawaqeet-prayer-card",
   name: "Mawaqeet Prayer",
   description: "Prayer times from a Mawaqeet location device",
   preview: !0
-});
+}));
 export {
   T as MawaqeetPrayerCard,
   W as MawaqeetPrayerCardEditor

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -1,0 +1,179 @@
+"""Validate repository automation blueprints against Home Assistant schemas."""
+
+from pathlib import Path
+
+import pytest
+from homeassistant.components.automation.config import (
+    AUTOMATION_BLUEPRINT_SCHEMA,
+    ValidationStatus,
+    _async_validate_config_item,
+)
+from homeassistant.components.blueprint.const import CONF_INPUT, CONF_USE_BLUEPRINT
+from homeassistant.components.blueprint.models import Blueprint, BlueprintInputs
+from homeassistant.const import CONF_LATITUDE, CONF_LOCATION, CONF_LONGITUDE, CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.util import yaml as yaml_util
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.mawaqeet.const import CALCULATION_METHOD, DOMAIN
+
+BLUEPRINTS_DIR = Path(__file__).resolve().parents[1] / "blueprints"
+
+EMPTY_MEDIA = {"media_content_id": "", "media_content_type": "music"}
+
+FAKE_MEDIA = {
+    "media_content_id": "media-source://test/adhan.mp3",
+    "media_content_type": "music",
+}
+
+# Minimal inputs per blueprint (merged with blueprint defaults where defined).
+MINIMAL_BLUEPRINT_INPUTS: dict[str, dict] = {
+    "prayer_reminder_notify.yaml": {
+        "tts_entity": "media_player.test",
+    },
+    "fajr_wakeup.yaml": {
+        "target_lights": [],
+        "people": [],
+        "optional_media": EMPTY_MEDIA,
+    },
+    "prayer_time_lights.yaml": {
+        "target_lights": [],
+        "target_scene": "",
+    },
+}
+
+
+@pytest.fixture
+async def mawaqeet_device_id(hass: HomeAssistant) -> str:
+    """Mawaqeet device registry id for blueprint triggers."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_NAME: "Home",
+            CONF_LOCATION: {CONF_LATITUDE: 51.5, CONF_LONGITUDE: -0.12},
+            CALCULATION_METHOD: "mwl",
+        },
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    from homeassistant.helpers import device_registry as dr
+
+    device = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    assert device is not None
+    return device.id
+
+
+def _load_blueprint(path: Path) -> dict:
+    return yaml_util.load_yaml_dict(path)
+
+
+def _substituted_automation(
+    blueprint_data: dict,
+    blueprint_path: str,
+    inputs: dict,
+) -> dict:
+    blueprint = Blueprint(
+        blueprint_data,
+        expected_domain="automation",
+        path=blueprint_path,
+        schema=AUTOMATION_BLUEPRINT_SCHEMA,
+    )
+    instance_config = {
+        CONF_USE_BLUEPRINT: {
+            "path": blueprint_path,
+            CONF_INPUT: inputs,
+        },
+        "alias": "Blueprint schema test",
+    }
+    blueprint_inputs = BlueprintInputs(blueprint, instance_config)
+    blueprint_inputs.validate()
+    return blueprint_inputs.async_substitute()
+
+
+@pytest.mark.parametrize(
+    "blueprint_path",
+    sorted(BLUEPRINTS_DIR.glob("*.yaml")),
+    ids=lambda p: p.name,
+)
+def test_blueprint_yaml_matches_automation_schema(blueprint_path: Path) -> None:
+    """Blueprint metadata and structure must match Home Assistant automation blueprint schema."""
+    data = _load_blueprint(blueprint_path)
+    AUTOMATION_BLUEPRINT_SCHEMA(data)
+
+
+@pytest.mark.parametrize(
+    "blueprint_name",
+    sorted(MINIMAL_BLUEPRINT_INPUTS.keys()),
+)
+async def test_blueprint_generated_automation_valid(
+    hass: HomeAssistant,
+    mawaqeet_device_id: str,
+    blueprint_name: str,
+) -> None:
+    """Substituted automation must pass full HA validation (triggers, conditions, actions)."""
+    path = BLUEPRINTS_DIR / blueprint_name
+    data = _load_blueprint(path)
+    inputs = {
+        "device_id": mawaqeet_device_id,
+        **MINIMAL_BLUEPRINT_INPUTS[blueprint_name],
+    }
+    config = _substituted_automation(data, blueprint_name, inputs)
+    result = await _async_validate_config_item(hass, config, True, False)
+    assert result.validation_status == ValidationStatus.OK, result.validation_error
+
+
+@pytest.mark.parametrize(
+    ("blueprint_name", "playback_mode"),
+    [
+        ("adhan_home_assistant.yaml", "media_playback"),
+        ("adhan_home_assistant.yaml", "announcement"),
+        ("adhan_music_assistant.yaml", "media_playback"),
+        ("adhan_music_assistant.yaml", "announcement"),
+    ],
+)
+async def test_adhan_blueprint_modes_validate(
+    hass: HomeAssistant,
+    mawaqeet_device_id: str,
+    blueprint_name: str,
+    playback_mode: str,
+) -> None:
+    """Adhan blueprints validate for each playback mode with defaults-only unused media."""
+    path = BLUEPRINTS_DIR / blueprint_name
+    data = _load_blueprint(path)
+    inputs = {
+        "device_id": mawaqeet_device_id,
+        "playback_mode": playback_mode,
+        "player_fajr": ["media_player.test_fajr"],
+        "player_other": ["media_player.test_other"],
+    }
+    if playback_mode == "media_playback":
+        inputs["media_fajr_playback"] = FAKE_MEDIA
+        inputs["media_other_playback"] = FAKE_MEDIA
+    else:
+        inputs["media_fajr_announce"] = FAKE_MEDIA
+        inputs["media_other_announce"] = FAKE_MEDIA
+
+    config = _substituted_automation(data, blueprint_name, inputs)
+    result = await _async_validate_config_item(hass, config, True, False)
+    assert result.validation_status == ValidationStatus.OK, result.validation_error
+
+
+async def test_adhan_blueprint_defaults_only_unused_media(
+    hass: HomeAssistant,
+    mawaqeet_device_id: str,
+) -> None:
+    """Adhan blueprints accept blueprint defaults for unused mode-specific media fields."""
+    for blueprint_name in ("adhan_home_assistant.yaml", "adhan_music_assistant.yaml"):
+        path = BLUEPRINTS_DIR / blueprint_name
+        data = _load_blueprint(path)
+        inputs = {
+            "device_id": mawaqeet_device_id,
+            "playback_mode": "media_playback",
+            "player_fajr": ["media_player.test_fajr"],
+            "player_other": ["media_player.test_other"],
+            "media_fajr_playback": FAKE_MEDIA,
+            "media_other_playback": FAKE_MEDIA,
+        }
+        config = _substituted_automation(data, blueprint_name, inputs)
+        result = await _async_validate_config_item(hass, config, True, False)
+        assert result.validation_status == ValidationStatus.OK, result.validation_error

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -12,6 +12,7 @@ from homeassistant.components.blueprint.const import CONF_INPUT, CONF_USE_BLUEPR
 from homeassistant.components.blueprint.models import Blueprint, BlueprintInputs
 from homeassistant.const import CONF_LATITUDE, CONF_LOCATION, CONF_LONGITUDE, CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.util import yaml as yaml_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -56,7 +57,6 @@ async def mawaqeet_device_id(hass: HomeAssistant) -> str:
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
-    from homeassistant.helpers import device_registry as dr
 
     device = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, entry.entry_id)})
     assert device is not None
@@ -65,6 +65,20 @@ async def mawaqeet_device_id(hass: HomeAssistant) -> str:
 
 def _load_blueprint(path: Path) -> dict:
     return yaml_util.load_yaml_dict(path)
+
+
+async def _validate_substituted_automation(
+    hass: HomeAssistant,
+    config: dict,
+) -> None:
+    """Run full HA automation validation; raises on schema errors."""
+    result = await _async_validate_config_item(
+        hass,
+        config,
+        raise_on_errors=True,
+        warn_on_errors=False,
+    )
+    assert result.validation_status == ValidationStatus.OK, result.validation_error
 
 
 def _substituted_automation(
@@ -96,7 +110,7 @@ def _substituted_automation(
     ids=lambda p: p.name,
 )
 def test_blueprint_yaml_matches_automation_schema(blueprint_path: Path) -> None:
-    """Blueprint metadata and structure must match Home Assistant automation blueprint schema."""
+    """Blueprint YAML must match Home Assistant automation blueprint schema."""
     data = _load_blueprint(blueprint_path)
     AUTOMATION_BLUEPRINT_SCHEMA(data)
 
@@ -110,7 +124,7 @@ async def test_blueprint_generated_automation_valid(
     mawaqeet_device_id: str,
     blueprint_name: str,
 ) -> None:
-    """Substituted automation must pass full HA validation (triggers, conditions, actions)."""
+    """Substituted automation passes HA trigger, condition, and action validation."""
     path = BLUEPRINTS_DIR / blueprint_name
     data = _load_blueprint(path)
     inputs = {
@@ -118,8 +132,7 @@ async def test_blueprint_generated_automation_valid(
         **MINIMAL_BLUEPRINT_INPUTS[blueprint_name],
     }
     config = _substituted_automation(data, blueprint_name, inputs)
-    result = await _async_validate_config_item(hass, config, True, False)
-    assert result.validation_status == ValidationStatus.OK, result.validation_error
+    await _validate_substituted_automation(hass, config)
 
 
 @pytest.mark.parametrize(
@@ -137,7 +150,7 @@ async def test_adhan_blueprint_modes_validate(
     blueprint_name: str,
     playback_mode: str,
 ) -> None:
-    """Adhan blueprints validate for each playback mode with defaults-only unused media."""
+    """Adhan blueprints validate per playback mode with default unused media."""
     path = BLUEPRINTS_DIR / blueprint_name
     data = _load_blueprint(path)
     inputs = {
@@ -154,15 +167,14 @@ async def test_adhan_blueprint_modes_validate(
         inputs["media_other_announce"] = FAKE_MEDIA
 
     config = _substituted_automation(data, blueprint_name, inputs)
-    result = await _async_validate_config_item(hass, config, True, False)
-    assert result.validation_status == ValidationStatus.OK, result.validation_error
+    await _validate_substituted_automation(hass, config)
 
 
 async def test_adhan_blueprint_defaults_only_unused_media(
     hass: HomeAssistant,
     mawaqeet_device_id: str,
 ) -> None:
-    """Adhan blueprints accept blueprint defaults for unused mode-specific media fields."""
+    """Adhan blueprints accept defaults for unused mode-specific media fields."""
     for blueprint_name in ("adhan_home_assistant.yaml", "adhan_music_assistant.yaml"):
         path = BLUEPRINTS_DIR / blueprint_name
         data = _load_blueprint(path)
@@ -175,5 +187,4 @@ async def test_adhan_blueprint_defaults_only_unused_media(
             "media_other_playback": FAKE_MEDIA,
         }
         config = _substituted_automation(data, blueprint_name, inputs)
-        result = await _async_validate_config_item(hass, config, True, False)
-        assert result.validation_status == ValidationStatus.OK, result.validation_error
+        await _validate_substituted_automation(hass, config)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -83,6 +83,47 @@ async def test_register_lovelace_resource(hass: HomeAssistant) -> None:
     assert hass.data[DOMAIN]["lovelace_resource_registered"] is True
 
 
+async def test_setup_entry_defers_lovelace_until_hass_started(hass: HomeAssistant) -> None:
+    """Test Lovelace registration waits for homeassistant_started when HA is not running."""
+    created_items: list[dict] = []
+
+    class MockLovelaceResources:
+        def async_items(self) -> list:
+            return []
+
+        async def async_create_item(self, item: dict) -> None:
+            created_items.append(item)
+
+    class MockLovelace:
+        mode = "storage"
+        resources = MockLovelaceResources()
+
+    await async_setup_component(hass, "lovelace", {})
+    hass.data["lovelace"] = MockLovelace()
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_NAME: "Home",
+            CONF_LOCATION: {CONF_LATITUDE: 51.5074, CONF_LONGITUDE: -0.1278},
+            CALCULATION_METHOD: "mwl",
+        },
+        options={MADHAB: "shafi"},
+    )
+    entry.add_to_hass(hass)
+
+    hass.is_running = False
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    assert created_items == []
+
+    hass.is_running = True
+    hass.bus.async_fire("homeassistant_started")
+    await hass.async_block_till_done()
+
+    assert len(created_items) == 1
+    assert hass.data[DOMAIN]["lovelace_resource_registered"] is True
+
+
 async def test_setup_entry_registers_lovelace_resource(hass: HomeAssistant) -> None:
     """Test config entry setup auto-registers the Lovelace card resource."""
     created_items: list[dict] = []

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -83,8 +83,10 @@ async def test_register_lovelace_resource(hass: HomeAssistant) -> None:
     assert hass.data[DOMAIN]["lovelace_resource_registered"] is True
 
 
-async def test_setup_entry_defers_lovelace_until_hass_started(hass: HomeAssistant) -> None:
-    """Test Lovelace registration waits for homeassistant_started when HA is not running."""
+async def test_setup_entry_defers_lovelace_until_hass_started(
+    hass: HomeAssistant,
+) -> None:
+    """Lovelace registration waits for homeassistant_started if HA is not running."""
     created_items: list[dict] = []
 
     class MockLovelaceResources:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -97,6 +97,30 @@ async def test_trigger_prayer_reminder_event(hass: HomeAssistant) -> None:
     assert state.attributes.get("event_type") == "dhuhr"
 
 
+async def test_trigger_event_rejects_unknown_config_entry(hass: HomeAssistant) -> None:
+    """Test trigger_event rejects a missing or foreign config entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Home",
+        data=_entry_data(),
+        options={MADHAB: "shafi"},
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+
+    with pytest.raises(ServiceValidationError, match="not found"):
+        await hass.services.async_call(
+            DOMAIN,
+            "trigger_event",
+            {
+                CONF_CONFIG_ENTRY: "missing-entry-id",
+                CONF_TRIGGER_TYPE: PRAYER_TIME_TRIGGER,
+                PRAYER: "fajr",
+            },
+            blocking=True,
+        )
+
+
 async def test_trigger_event_requires_loaded_entry(hass: HomeAssistant) -> None:
     """Test trigger_event rejects an unloaded config entry."""
     entry = MockConfigEntry(


### PR DESCRIPTION
## Summary

- **Adhan blueprints:** Replace invalid `repeat` + `parallel: true` with multi-target `music_assistant` / `media_player` actions; optional player/media inputs with defaults; guard play when `media_content_id` is empty.
- **Lovelace card:** Add `getGridOptions()` for Sections dashboard resizing; card fills grid cell height.
- **Tests:** Blueprint schema validation (`test_blueprints.py`); coverage restored to 95%.

## Test plan

- [x] CI: Test, Frontend, Lint, Validate on `dev` (df13c8e)
- [ ] Re-import adhan blueprints in HA and save automations
- [ ] Verify prayer card resize on Sections dashboard (Layout tab)
- [ ] Trigger adhan with multiple speakers (MA and HA blueprints)
