### PR TITLE
Release 0.4.4

### DIFF
--- a/.cursor/commands/release.md
+++ b/.cursor/commands/release.md
@@ -1,0 +1,143 @@
+# Release
+
+Execute the release pipeline for **ha-mawaqeet**. This integration publishes via **GitHub Release → `release.yml` → `mawaqeet.zip`** (HACS `zip_release`). There is no Docker image, no root `VERSION` file, and no Pages gate.
+
+Shell and Python execution must follow `.cursor/rules/shell.mdc`, `.cursor/rules/windows-shell.mdc`, and `.cursor/rules/python.mdc` (bash/Git Bash on Windows; Docker for pytest when host Python cannot run HA).
+
+## Version resolution
+
+Determine `{VERSION}` once (semver, no leading `v` in user text after stripping; Git tag **includes** `v`).
+
+| User invocation | `{VERSION}` |
+|-----------------|-------------|
+| `/release` (no version) | Bump semver (default **patch**) from `max(latest GitHub release tag without v, manifest.json version)`. |
+| `/release 0.4.4` | Explicit stable `0.4.4`. |
+| `/release 0.4.4-beta.1` | Explicit pre-release string. |
+
+**Parsing rules** (from user message text after the command):
+
+1. Strip optional leading `v` / `V`.
+2. Must match `^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$`.
+3. **Pre-release** = version contains `-` after `major.minor.patch`.
+4. If user says “beta” / “prerelease” / “rc” **without** a version → stop and ask.
+5. **Never invent** a pre-release from manifest alone — pre-releases are always user-specified.
+
+Convention for successive betas on the same base: increment the numeric suffix (`-beta.1` → `-beta.2`).
+
+**Resolving the bump base** (when user omits an explicit version):
+
+```bash
+gh release view --json tagName --jq .tagName   # e.g. v0.4.3 → 0.4.3
+# and read custom_components/mawaqeet/manifest.json → .version
+# base = max(tag_without_v, manifest_version) by semver
+# default new version = patch bump of base
+```
+
+Canonical in-tree version lives in `custom_components/mawaqeet/manifest.json` (`"version"`, no `v` prefix). Git tag is `v{VERSION}`.
+
+`.github/workflows/release.yml` strips a leading `v`/`V` from the release tag when writing the packaged `manifest.json`, so the HACS zip gets `"version": "{VERSION}"` (not `v{VERSION}`).
+
+## Release kinds
+
+| Kind | `{VERSION}` example | GitHub Release | HACS |
+|------|---------------------|----------------|------|
+| Stable | `0.4.4` | normal (tag `v0.4.4`) | default channel |
+| Pre-release | `0.4.4-beta.1` | `prerelease: true` (tag `v0.4.4-beta.1`) | beta / explicit |
+
+`hacs.json` already has `"zip_release": true` and `"filename": "mawaqeet.zip"` — the Release workflow must attach **`mawaqeet.zip`**.
+
+## 1. Prepare version and docs (single branch)
+
+1. Resolve `{VERSION}` as above.
+2. Update `"version"` in `custom_components/mawaqeet/manifest.json` to `{VERSION}` (no `v` prefix).
+3. Update README / CONTRIBUTING / translations if user-facing behavior changed.
+4. **Do not commit** unless the user explicitly asks; stage changes and report `git status`.
+
+## 2. Local checks (once, before opening the PR)
+
+Run and fix failures before proceeding:
+
+```bash
+bash scripts/lint
+bash scripts/test
+```
+
+On Windows if host pytest fails (`fcntl` / HA), use Docker per `python.mdc`.
+
+If any files under `custom_components/mawaqeet/frontend/` changed, also run:
+
+```bash
+python scripts/build_frontend.py
+```
+
+Do **not** re-run the full suite after merge if CI will run the same jobs — local checks are the pre-push gate only.
+
+## 3. One PR → merge to `main`
+
+- Create **one** release branch with version bump and code changes together.
+- Open a PR and merge to `main` (use `gh` for GitHub tasks).
+- Workflows also gate `dev`; publish releases from `main`.
+
+## 4. Gate: CI green on the merge commit
+
+After merge, wait for workflows triggered by that push:
+
+```bash
+git fetch origin main
+MERGE_SHA="$(git rev-parse origin/main)"
+gh run list --commit "$MERGE_SHA" --limit 10
+gh run watch --exit-status $(gh run list --workflow=test.yml --commit "$MERGE_SHA" --json databaseId --jq '.[0].databaseId')
+gh run watch --exit-status $(gh run list --workflow=lint.yml --commit "$MERGE_SHA" --json databaseId --jq '.[0].databaseId')
+gh run watch --exit-status $(gh run list --workflow=validate.yml --commit "$MERGE_SHA" --json databaseId --jq '.[0].databaseId')
+gh run watch --exit-status $(gh run list --workflow=frontend.yml --commit "$MERGE_SHA" --json databaseId --jq '.[0].databaseId')
+```
+
+**Stop here** until **Test**, **Lint**, **Validate** (hassfest + HACS), and **Frontend** all succeed. Do not create the GitHub Release yet.
+
+## 5. Publish GitHub Release (triggers packaging)
+
+On latest `main` after gates pass, create a **published** GitHub Release for tag `v{VERSION}` (this fires `release.yml` on `release: published`):
+
+```bash
+git checkout main && git pull origin main
+gh release create "v{VERSION}" --title "v{VERSION}" --generate-notes
+# For pre-release:
+# gh release create "v{VERSION}" --title "v{VERSION}" --generate-notes --prerelease
+```
+
+If the tag already exists locally/remotely without a Release, prefer `gh release create` against that tag rather than deleting/recreating tags.
+
+`.github/workflows/release.yml` then:
+
+- Checks out the repo at the release tag
+- Sets packaged `custom_components/mawaqeet/manifest.json` `version` to `{VERSION}` (leading `v`/`V` stripped from the tag)
+- Zips `custom_components/mawaqeet/` → `mawaqeet.zip`, excluding `frontend/` (Node sources; keep `www/`), `__pycache__`/`*.pyc`, and `brand/src/` (keep rendered brand PNGs)
+- Uploads **`mawaqeet.zip`** to the GitHub Release
+
+## 6. Gate: Release workflow green
+
+```bash
+gh run watch --exit-status $(gh run list --workflow=release.yml --limit=1 --json databaseId --jq '.[0].databaseId')
+gh release view "v{VERSION}"
+gh release view "v{VERSION}" --json assets --jq '.assets[].name'
+# must include: mawaqeet.zip
+```
+
+For pre-releases, confirm `isPrerelease` / `--prerelease`. Report the release URL and zip asset when complete.
+
+## Pitfalls
+
+| Pitfall | Consequence |
+|---------|-------------|
+| Tag/Release before CI green | Broken HACS zip from unvalidated code |
+| Bump from stale tree `manifest.json` only (ignore GitHub tags) | Under-release (e.g. `0.4.1` after `v0.4.3`) |
+| Delete/recreate tag after failed release | Duplicate noise; prefer a patch bump instead |
+| Release missing `mawaqeet.zip` | HACS `zip_release` installs break |
+| Extra unnamed `.zip` assets on the Release | HACS may pick the wrong file |
+| Skip frontend build when card sources changed | CI Frontend fails or stale card in zip |
+| Shipping `frontend/` or `brand/src/` inside `mawaqeet.zip` | Bloated/broken HACS install; exclusions live in `release.yml` |
+| Windows host pytest without Docker | Often fails; use Docker per `python.mdc` |
+
+## Reporting
+
+At each step, summarize: kind (stable / pre-release), `{VERSION}`, what changed, gate status (Test / Lint / Validate / Frontend / Release), and release URL. If the tree is already release-ready on `main`, skip to step 4.

--- a/.cursor/rules/python.mdc
+++ b/.cursor/rules/python.mdc
@@ -1,0 +1,39 @@
+---
+description: Python 3.14+ execution for this Home Assistant custom integration
+alwaysApply: true
+---
+
+# Python execution (agents)
+
+- **Minimum version: Python 3.14+** — matches CI (`actions/setup-python` with `3.14`).
+- Prefer repo scripts from the project root (after `scripts/setup` when deps are missing):
+  - Install deps: `bash scripts/setup`
+  - Tests (pinned HA): `bash scripts/test`
+  - Tests (latest HA, same as CI “latest” leg): `HA_TEST_LATEST=1 bash scripts/test`
+  - Lint/format: `bash scripts/lint`
+  - Local HA instance: `bash scripts/develop` (or use [`.devcontainer.json`](.devcontainer.json) — supported local HA path; **no** Docker Compose in this repo)
+  - Lovelace card: `python scripts/build_frontend.py`
+- On Windows (host Python often fails HA/`fcntl`): run tests via **Docker**. Prefer invoking the repo script inside the container:
+
+  ```bash
+  docker run --rm -v "/c/Projects/HomeAssistant/ha-mawaqeet:/repo" -w /repo \
+    -e PIP_DISABLE_PIP_VERSION_CHECK=1 -e PIP_PREFER_BINARY=1 \
+    python:3.14-bookworm bash scripts/test
+  ```
+
+  Fallback (same flags as `scripts/test` / CI: 95% coverage):
+
+  ```bash
+  docker run --rm -v "/c/Projects/HomeAssistant/ha-mawaqeet:/repo" -w /repo \
+    -e PIP_DISABLE_PIP_VERSION_CHECK=1 -e PIP_PREFER_BINARY=1 \
+    python:3.14-bookworm bash -lc '
+      pip install -r requirements-test.txt pytest-cov &&
+      python -m pytest tests/ -v \
+        --cov=custom_components/mawaqeet \
+        --cov-report=term-missing \
+        --cov-fail-under=95
+    '
+  ```
+
+- **Do not** assume PowerShell `python` is 3.14+ or that HA tests work on Windows without Docker/WSL.
+- Do not invent solar-style `docker compose` for this repo (none exists).

--- a/.cursor/rules/shell.mdc
+++ b/.cursor/rules/shell.mdc
@@ -1,0 +1,13 @@
+---
+description: Shell conventions — bash/Git Bash/WSL/Docker on Windows
+alwaysApply: true
+---
+
+# Shell execution (agents)
+
+- Use **bash**, **WSL**, or **Docker exec** for shell commands.
+- On Windows, avoid PowerShell-native syntax (`$env:`, backtick continuations, `%CD%`).
+- Use POSIX paths in Docker volume mounts: `-v "/c/Projects/HomeAssistant/ha-mawaqeet:/repo"`.
+- Prefer Linux commands; use Docker when the host shell differs from CI (Ubuntu + bash).
+- On Windows hosts, see **`windows-shell.mdc`** for path formats, `bash -lc` wrapping, and Docker volume mounts.
+- Under `scripts/`: invoke **bash scripts** as `bash scripts/<name>` (`setup`, `lint`, `test`, `develop`). Invoke **Python** scripts as `python scripts/<name>.py` (`build_frontend.py`, brand helpers) — not via `bash`.

--- a/.cursor/rules/windows-shell.mdc
+++ b/.cursor/rules/windows-shell.mdc
@@ -1,0 +1,62 @@
+---
+description: Windows host shell paths, Git Bash, and Docker execution for agents
+alwaysApply: true
+---
+
+# Windows shell execution (agents)
+
+Cursor on this machine may run **PowerShell** even when commands look like bash. Repo root: `C:\Projects\HomeAssistant\ha-mawaqeet` (Git Bash: `/c/Projects/HomeAssistant/ha-mawaqeet`).
+
+## When to use which approach
+
+- **Simple commands** with no pipes, no `$()`, no HEREDOC: set Shell tool `working_directory` to `C:\Projects\HomeAssistant\ha-mawaqeet` and run them directly.
+- **Everything else** (pipes, `head`/`grep`, `$(pwd)`, `scripts/*`, git HEREDOC, `source .venv/bin/activate`): wrap in `bash -lc '…'`.
+
+## Path rules
+
+| Context | Format | Example |
+|---------|--------|---------|
+| Shell tool `working_directory` | Windows backslashes OK | `C:\Projects\HomeAssistant\ha-mawaqeet` |
+| Docker `-v` from PowerShell | Docker Desktop style | `"/c/Projects/HomeAssistant/ha-mawaqeet:/repo"` |
+| Inside WSL bash (`bash -lc`) | WSL mount path | `/mnt/c/Projects/HomeAssistant/ha-mawaqeet` |
+
+Never use `C:\…` backslashes inside Docker volume strings.
+
+`$(pwd)` and repo scripts must run inside bash, not bare PowerShell. When `bash -lc` lands in WSL, `cd` to `/mnt/c/Projects/HomeAssistant/ha-mawaqeet` (or rely on `working_directory` and skip `cd`).
+
+## Repo-canonical commands
+
+From repo root (`working_directory` or `cd "c:/Projects/HomeAssistant/ha-mawaqeet" &&`):
+
+```bash
+bash scripts/setup
+bash scripts/lint
+bash scripts/test
+HA_TEST_LATEST=1 bash scripts/test
+bash scripts/develop
+python scripts/build_frontend.py
+```
+
+One-off container (preferred for pytest on Windows — prefer `scripts/test` inside the image):
+
+```bash
+docker run --rm -v "/c/Projects/HomeAssistant/ha-mawaqeet:/repo" -w /repo \
+  -e PIP_DISABLE_PIP_VERSION_CHECK=1 -e PIP_PREFER_BINARY=1 \
+  python:3.14-bookworm bash scripts/test
+```
+
+See `python.mdc` for Python/pytest policy and coverage flags.
+
+## Anti-patterns
+
+| Avoid (PowerShell) | Use instead |
+|--------------------|-------------|
+| `Select-Object -First N` | `bash -lc '… \| head -n N'` |
+| `Select-String -Pattern` | `bash -lc '… \| grep pattern'` |
+| `$env:VAR` / backtick continuations | `export VAR=…` inside `bash -lc` |
+| `cat <<'EOF'` for git commits | Full commit wrapped in `bash -lc '…'` |
+| `C:\Projects\…` in `docker -v` | `"/c/Projects/…"` |
+
+## On failure
+
+Retry once with `bash -lc` and POSIX paths before changing command logic or abandoning the approach.

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -31,10 +31,10 @@ jobs:
         working-directory: custom_components/mawaqeet/frontend
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: "24"
           cache: npm
@@ -60,15 +60,15 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.14"
 
       - name: Restore pip cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-latest-frontend-${{ hashFiles('requirements-test.txt') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,10 +27,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.14"
           cache: "pip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,22 @@ jobs:
       - name: "Adjust version number"
         shell: "bash"
         run: |
-          yq -i -o json '.version="${{ github.event.release.tag_name }}"' \
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          VERSION="${VERSION#V}"
+          yq -i -o json ".version=\"${VERSION}\"" \
             "${{ github.workspace }}/custom_components/mawaqeet/manifest.json"
 
       - name: "ZIP the integration directory"
         shell: "bash"
         run: |
           cd "${{ github.workspace }}/custom_components/mawaqeet"
-          zip mawaqeet.zip -r ./
+          zip mawaqeet.zip -r ./ \
+            -x "frontend/*" \
+            -x "*/__pycache__/*" \
+            -x "*__pycache__*" \
+            -x "*.pyc" \
+            -x "brand/src/*"
 
       - name: "Upload the ZIP file to the release"
         uses: softprops/action-gh-release@v3.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: "Checkout the repository"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: "Adjust version number"
         shell: "bash"
@@ -30,6 +30,6 @@ jobs:
           zip mawaqeet.zip -r ./
 
       - name: "Upload the ZIP file to the release"
-        uses: softprops/action-gh-release@v2.0.8
+        uses: softprops/action-gh-release@v3.0.1
         with:
           files: ${{ github.workspace }}/custom_components/mawaqeet/mawaqeet.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         ha-version: [pinned, latest]
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: Read pinned Home Assistant version
         id: ha_pin
@@ -40,12 +40,12 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.14"
 
       - name: Restore pip cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.ha-version }}-${{ hashFiles('requirements-test.txt') }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,19 +25,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: Run hassfest validation
-        uses: home-assistant/actions/hassfest@d56d093b9ab8d2105bc0cb6ee9bcc0ef4ec8b96d # master
+        uses: home-assistant/actions/hassfest@master
 
   hacs: # https://github.com/hacs/action
     name: HACS validation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: Run HACS validation
-        uses: hacs/action@d556e736723344f83838d08488c983a15381059a # 22.5.0
+        uses: hacs/action@22.5.0
         with:
           category: integration

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -13,6 +13,7 @@ ignore = [
     "D212", # multi-line-summary-first-line (incompatible with formatter)
     "COM812", # incompatible with formatter
     "ISC001", # incompatible with formatter
+    "EXE002", # executable bit noise on Windows/Docker bind mounts
 ]
 
 [lint.flake8-pytest-style]
@@ -43,3 +44,5 @@ max-complexity = 25
 "custom_components/mawaqeet/coordinator.py" = ["TC002"]
 "custom_components/mawaqeet/device_trigger.py" = ["TC002"]
 "custom_components/mawaqeet/frontend.py" = ["TC002", "PLR0911", "PLR0912"]
+"custom_components/mawaqeet/preview.py" = ["TC002"]
+"custom_components/mawaqeet/calculation.py" = ["TC003"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,21 @@ Coverage is enforced at 95% for `custom_components/mawaqeet` (same flags as CI).
 HA_TEST_LATEST=1 scripts/test
 ```
 
-CI runs both on every push and pull request to `main` (see [`.github/workflows/test.yml`](.github/workflows/test.yml)).
+On Windows, host Python often fails with Home Assistant (`fcntl`). Prefer Docker:
+
+```bash
+docker run --rm -v "/c/Projects/HomeAssistant/ha-mawaqeet:/repo" -w /repo \
+  -e PIP_DISABLE_PIP_VERSION_CHECK=1 -e PIP_PREFER_BINARY=1 \
+  python:3.14-bookworm bash scripts/test
+```
+
+When changing the Lovelace card under `custom_components/mawaqeet/frontend/`, rebuild the committed bundle:
+
+```bash
+python scripts/build_frontend.py
+```
+
+CI (Test, Lint, Validate, Frontend) runs on every push and pull request to **`main`** and **`dev`** (see [`.github/workflows/`](.github/workflows/)).
 
 This custom component is based on [integration_blueprint](https://github.com/ludeeus/integration_blueprint). A dev container (`.devcontainer.json`) provides a standalone Home Assistant instance with [`config/configuration.yaml`](./config/configuration.yaml).
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,13 @@ Requires [HACS](https://hacs.xyz/). If this repository is not listed yet, add `h
 
 Configuration is done in the UI. Supported languages: **English**, **Arabic** (match your Home Assistant profile language).
 
-1. **Initial setup**: name, map location, and calculation method (MWL, ISNA, Umm Al-Qura, custom, etc.).
-2. **Adjustments** (options): madhab (Shafi/Hanafi), per-prayer **calculation** offsets (minutes), optional custom angles for the custom method, and per-prayer **reminder** lead times.
-3. **Reconfigure** (from the integration menu): change name, location, or calculation method without removing the entry.
+1. **Initial setup**: name and map location, then calculation method (MWL, ISNA, Umm Al-Qura, custom, etc.).
+2. **Adjustments** (same setup flow and later via Configure): madhab (Shafi/Hanafi), per-prayer **calculation** offsets (minutes), optional custom angles for the custom method, and per-prayer **reminder** lead times.
+3. **Reconfigure** (from the integration menu): change name or location without removing the entry. Change calculation method from **Configure** (options).
 
 Saving **options** or completing **reconfigure** reloads the integration automatically so prayer times and reminders pick up changes immediately.
+
+On the **calculation method** and **adjustments** steps, a live preview shows today’s prayer times and updates as you change method, madhab, or offsets (Home Assistant stock single-row preview).
 
 ### Configuration parameters
 
@@ -56,7 +58,7 @@ Saving **options** or completing **reconfigure** reloads the integration automat
 | --- | --- | --- |
 | Name | Yes | No |
 | Location (lat/lon) | Yes (reconfigure) | No |
-| Calculation method | Yes (reconfigure) | No |
+| Calculation method | No | Yes |
 | Madhab | No | Yes |
 | Per-prayer calculation offsets | No | Yes |
 | Custom angles / high-latitude rule | No (custom method) | Yes |
@@ -150,7 +152,7 @@ Prayer times are calculated locally (no cloud API). The coordinator refreshes at
 
 - Prayer times are **calculated locally** from coordinates and method settings; there is no link to a specific mosque timetable or cloud API.
 - **Shuruq**, **Midnight**, and **Last Third** are optional sensors; automations for the five daily prayers use Fajr through Ishaa.
-- **Reminder** events cover Fajr through Ishaa only (not Shuruq, Midnight, or Last Third).
+- **Reminder** events cover Fajr through Ishaa **including Shuruq** (not Midnight or Last Third).
 - Only **one config entry** per map position is allowed.
 - The custom Lovelace card requires adding a [Lovelace resource](#dashboard-cards) (served by the integration).
 
@@ -159,7 +161,7 @@ Prayer times are calculated locally (no cloud API). The coordinator refreshes at
 | Symptom | Things to check |
 | --- | --- |
 | Times differ from local mosque | Calculation method, madhab (Asr), and per-prayer offsets in options |
-| High-latitude odd times | Enable custom method and set high-latitude rule if needed |
+| High-latitude odd times | Set high-latitude rule in options (Configure → adjustments) |
 | Reminders not firing | Options → prayer reminders enabled; per-prayer minutes set; automations listen to reminder events |
 | Duplicate location rejected | One entry per map position; remove or reconfigure the existing entry |
 
@@ -178,6 +180,12 @@ type: custom:mawaqeet-prayer-card
 device: DEVICE_ID_FROM_SETTINGS
 layout: next
 show_shuruq: false
+show_midnight: false
+show_last_third: false
+# Optional per-prayer icon overrides (MDI). Omit a key to use the default.
+# icons:
+#   fajr: mdi:weather-sunset-up
+#   midnight: mdi:clock-time-twelve
 ```
 
 Pick the device under **Settings → Devices & services → Mawaqeet →** your location. Each config entry is one device.
@@ -204,7 +212,15 @@ lovelace:
 | `timeline` | Day timeline from Fajr to Ishaa |
 | `agenda` | “Earlier today” and “Upcoming” sections |
 
-By default the card shows the five daily prayers (Fajr, Dhuhr, Asr, Maghrib, Ishaa). Enable **Show Shuruq** in the card editor to include sunrise.
+By default the card shows the five daily prayers (Fajr, Dhuhr, Asr, Maghrib, Ishaa). Optional toggles in the card editor:
+
+| Option | Adds |
+| --- | --- |
+| **Show Shuruq** | Sunrise (between Fajr and Dhuhr) |
+| **Show Midnight** | Islamic midnight (after Ishaa) |
+| **Show Last Third** | Last third of the night (after Midnight) |
+
+Use **Custom prayer icons** in the editor (or the `icons` map in YAML) to override MDI icons per time. Leave a field empty to keep the built-in default.
 
 ### Troubleshooting
 
@@ -253,6 +269,18 @@ Run linting:
 ```bash
 scripts/lint
 ```
+
+On Windows, prefer Docker for pytest (host HA installs often fail):
+
+```bash
+docker run --rm -v "/c/Projects/HomeAssistant/ha-mawaqeet:/repo" -w /repo \
+  -e PIP_DISABLE_PIP_VERSION_CHECK=1 -e PIP_PREFER_BINARY=1 \
+  python:3.14-bookworm bash scripts/test
+```
+
+Rebuild the Lovelace card after frontend source changes: `python scripts/build_frontend.py`.
+
+Maintainers publish GitHub Releases (HACS `mawaqeet.zip`) via the Cursor `/release` command after CI is green on `main`.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 

--- a/custom_components/mawaqeet/__init__.py
+++ b/custom_components/mawaqeet/__init__.py
@@ -16,7 +16,11 @@ from . import frontend
 from .const import DOMAIN
 from .coordinator import MawaqeetDataUpdateCoordinator
 from .data import MawaqeetRuntimeData
-from .options import migrate_options, options_need_migration
+from .options import (
+    migrate_calculation_method,
+    migrate_options,
+    options_need_migration,
+)
 from .service import async_setup_services
 
 if TYPE_CHECKING:
@@ -59,6 +63,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: MawaqeetConfigEntry) -> 
                 "homeassistant_started", _register_lovelace_on_started
             )
         )
+
+    migrate_calculation_method(hass, entry)
 
     if options_need_migration(entry.options):
         hass.config_entries.async_update_entry(

--- a/custom_components/mawaqeet/calculation.py
+++ b/custom_components/mawaqeet/calculation.py
@@ -12,8 +12,16 @@ from adhanpy.PrayerTimes import (  # type: ignore[import-untyped]
 )
 from homeassistant.const import CONF_LATITUDE, CONF_LOCATION, CONF_LONGITUDE
 
-from .const import FAJR_ANGLE, HIGH_LATITUDE_RULE, ISHAA_ANGLE, ISHAA_INTERVAL, MADHAB
+from .const import (
+    CALCULATION_METHOD,
+    FAJR_ANGLE,
+    HIGH_LATITUDE_RULE,
+    ISHAA_ANGLE,
+    ISHAA_INTERVAL,
+    MADHAB,
+)
 from .enum import (
+    CalculationMethod,
     HighLatitudeRule,
     Madhab,
     PrayerAdjustment,
@@ -30,14 +38,16 @@ from .mapper import (
 from .options import get_calculation_method
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from homeassistant.core import HomeAssistant
 
     from .data import MawaqeetConfigEntry
     from .models import Coordinates, MawaqeetData, PrayerTimeConfig, PrayerTimeEntries
 
 
-def _get_adjustments(config_entry: MawaqeetConfigEntry) -> Any:
-    options = config_entry.options
+def _get_adjustments(options: Mapping[str, Any]) -> Any:
+    """Build adhanpy adjustments from options."""
     adjustments = PrayerAdjustments(
         fajr=int(options.get(str(PrayerAdjustment.FAJR), 0)),
         shuruq=int(options.get(str(PrayerAdjustment.SHURUQ), 0)),
@@ -49,21 +59,24 @@ def _get_adjustments(config_entry: MawaqeetConfigEntry) -> Any:
     return PrayerAdjustmentMapper.to_adhanpy(adjustments)
 
 
-def _get_calculation_parameters(
-    config_entry: MawaqeetConfigEntry,
-) -> CalculationParameters:
-    options = config_entry.options
-    calculation_method = get_calculation_method(config_entry)
+def _get_calculation_parameters(options: Mapping[str, Any]) -> CalculationParameters:
+    """Build adhanpy calculation parameters from options."""
+    calculation_method = options.get(
+        CALCULATION_METHOD, str(CalculationMethod.MUSLIM_WORLD_LEAGUE)
+    )
     calc_method_params = CalculationMethodMapper.to_adhanpy(calculation_method)
 
-    calculation_parameters = CalculationParameters(
-        **{
-            "fajr_angle": float(options.get(FAJR_ANGLE, 0.0)),
-            "isha_angle": float(options.get(ISHAA_ANGLE, 0.0)),
+    if calculation_method == str(CalculationMethod.CUSTOM):
+        params: dict[str, Any] = {
+            "fajr_angle": float(options.get(FAJR_ANGLE, 18.0)),
+            "isha_angle": float(options.get(ISHAA_ANGLE, 18.0)),
             "isha_interval": int(options.get(ISHAA_INTERVAL, 0)),
             **calc_method_params,
         }
-    )
+    else:
+        params = dict(calc_method_params)
+
+    calculation_parameters = CalculationParameters(**params)
 
     madhab: str = options.get(MADHAB, Madhab.SHAFI)
     high_latitude_rule: str = options.get(
@@ -77,15 +90,16 @@ def _get_calculation_parameters(
 
 
 def _get_mawaqeet_parameters(
-    config_entry: MawaqeetConfigEntry,
+    location: Mapping[str, float],
+    options: Mapping[str, Any],
 ) -> tuple[Coordinates, CalculationParameters]:
-    location: dict[str, float] = config_entry.data.get(CONF_LOCATION, {})
+    """Resolve coordinates and calculation parameters."""
     coordinates: Coordinates = (
         float(location.get(CONF_LATITUDE, 0.0)),
         float(location.get(CONF_LONGITUDE, 0.0)),
     )
-    calculation_parameters = _get_calculation_parameters(config_entry)
-    calculation_parameters.adjustments = _get_adjustments(config_entry)
+    calculation_parameters = _get_calculation_parameters(options)
+    calculation_parameters.adjustments = _get_adjustments(options)
     return coordinates, calculation_parameters
 
 
@@ -93,16 +107,19 @@ def _get_night_times(
     today: PrayerTimes, tomorrow: PrayerTimes
 ) -> tuple[timedelta, datetime, datetime]:
     night_duration = tomorrow.fajr - today.maghrib
-    half_of_night = night_duration.seconds / 2
-    third_of_night = night_duration.seconds / 3
+    half_of_night = night_duration.total_seconds() / 2
+    third_of_night = night_duration.total_seconds() / 3
     midnight = tomorrow.fajr - timedelta(seconds=half_of_night)
     last_third = tomorrow.fajr - timedelta(seconds=third_of_night)
     return night_duration, midnight, last_third
 
 
-def compute_prayer_times(config_entry: MawaqeetConfigEntry) -> MawaqeetData:
-    """Compute prayer times synchronously (adhanpy; use executor from async)."""
-    coordinates, calculation_parameters = _get_mawaqeet_parameters(config_entry)
+def compute_prayer_times_from_options(
+    location: Mapping[str, float],
+    options: Mapping[str, Any],
+) -> MawaqeetData:
+    """Compute prayer times from location and options dictionaries."""
+    coordinates, calculation_parameters = _get_mawaqeet_parameters(location, options)
     today = dt_util.now()
     tomorrow = today + timedelta(days=1)
 
@@ -129,7 +146,9 @@ def compute_prayer_times(config_entry: MawaqeetConfigEntry) -> MawaqeetData:
     }
 
     calc_params = today_prayer.calculation_parameters
-    calc_method = get_calculation_method(config_entry)
+    calc_method = options.get(
+        CALCULATION_METHOD, str(CalculationMethod.MUSLIM_WORLD_LEAGUE)
+    )
     madhab = MadhabMapper.to_mawaqeet(calc_params.madhab)
     high_latitude_rule = HighLatitudeRuleMapper.to_mawaqeet(
         calc_params.high_latitude_rule
@@ -139,7 +158,7 @@ def compute_prayer_times(config_entry: MawaqeetConfigEntry) -> MawaqeetData:
         PrayerTimeOption.CALCULATION_METHOD: str(calc_method),
         PrayerTimeOption.MADHAB: str(madhab),
         PrayerTimeOption.NIGHT_LENGTH: today_prayer.night_length,
-        PrayerTimeOption.NIGHT_DURATION: night_duration.seconds,
+        PrayerTimeOption.NIGHT_DURATION: int(night_duration.total_seconds()),
         PrayerTimeOption.HIGH_LATITUDE_RULE: str(high_latitude_rule),
         PrayerTimeOption.FAJR_ANGLE: calc_params.fajr_angle,
         PrayerTimeOption.ISHAA_ANGLE: calc_params.isha_angle,
@@ -156,6 +175,16 @@ def compute_prayer_times(config_entry: MawaqeetConfigEntry) -> MawaqeetData:
         "prayer_times": prayer_times,
         "prayer_times_config": prayer_times_config,
     }
+
+
+def compute_prayer_times(config_entry: MawaqeetConfigEntry) -> MawaqeetData:
+    """Compute prayer times synchronously (adhanpy; use executor from async)."""
+    location: dict[str, float] = config_entry.data.get(CONF_LOCATION, {})
+    options = {
+        **config_entry.options,
+        CALCULATION_METHOD: get_calculation_method(config_entry),
+    }
+    return compute_prayer_times_from_options(location, options)
 
 
 async def async_compute_prayer_times(

--- a/custom_components/mawaqeet/config_flow.py
+++ b/custom_components/mawaqeet/config_flow.py
@@ -46,15 +46,19 @@ from .enum import (
     PrayerAdjustment,
     prayer_reminder_minutes_key,
 )
-from .options import migrate_options
+from .options import get_calculation_method, migrate_options
+from .preview import async_setup_preview
 
 REMINDER_MINUTES_SELECTOR = NumberSelector(
     NumberSelectorConfig(min=1, max=60, mode=NumberSelectorMode.BOX, step=1)
 )
 
-DATA_SCHEMA = {
+LOCATION_SCHEMA = {
     vol.Required(CONF_NAME): str,
     vol.Required(CONF_LOCATION): LocationSelector(LocationSelectorConfig()),
+}
+
+METHOD_SCHEMA = {
     vol.Required(CALCULATION_METHOD): SelectSelector(
         SelectSelectorConfig(
             options=[
@@ -77,16 +81,6 @@ CALCULATION_SCHEMA = {
     vol.Required(ISHAA_INTERVAL): NumberSelector(
         NumberSelectorConfig(min=0, max=120, mode=NumberSelectorMode.BOX, step=10)
     ),
-    vol.Optional(HIGH_LATITUDE_RULE): SelectSelector(
-        SelectSelectorConfig(
-            options=[
-                SelectOptionDict(value=str(r), label=str(r)) for r in HighLatitudeRule
-            ],
-            mode=SelectSelectorMode.DROPDOWN,
-            multiple=False,
-            translation_key=HIGH_LATITUDE_RULE,
-        )
-    ),
 }
 
 ADJUSTMENT_SCHEMA = {
@@ -96,6 +90,16 @@ ADJUSTMENT_SCHEMA = {
             mode=SelectSelectorMode.DROPDOWN,
             multiple=False,
             translation_key=MADHAB,
+        )
+    ),
+    vol.Optional(HIGH_LATITUDE_RULE): SelectSelector(
+        SelectSelectorConfig(
+            options=[
+                SelectOptionDict(value=str(r), label=str(r)) for r in HighLatitudeRule
+            ],
+            mode=SelectSelectorMode.DROPDOWN,
+            multiple=False,
+            translation_key=HIGH_LATITUDE_RULE,
         )
     ),
     vol.Optional(str(PrayerAdjustment.FAJR), 0): NumberSelector(
@@ -126,6 +130,7 @@ ADJUSTMENT_SCHEMA = {
 }
 
 DEFAULT_ADJUSTMENT_VALUES = {
+    MADHAB: str(Madhab.SHAFI),
     FAJR_ANGLE: 18,
     ISHAA_ANGLE: 18,
     ISHAA_INTERVAL: 0,
@@ -144,10 +149,10 @@ def _location_unique_id(location: dict[str, float]) -> str:
     return f"{latitude:.6f}_{longitude:.6f}"
 
 
-def _get_data_schema(
+def _get_location_schema(
     hass: HomeAssistant, config_entry: ConfigEntry | None = None
 ) -> dict:
-    """Get a schema with default values."""
+    """Get location schema defaults."""
     if config_entry is None:
         return {
             CONF_NAME: hass.config.location_name,
@@ -155,13 +160,11 @@ def _get_data_schema(
                 CONF_LATITUDE: hass.config.latitude,
                 CONF_LONGITUDE: hass.config.longitude,
             },
-            CALCULATION_METHOD: str(CalculationMethod.MUSLIM_WORLD_LEAGUE),
         }
 
     return {
         CONF_NAME: config_entry.data.get(CONF_NAME),
         CONF_LOCATION: config_entry.data.get(CONF_LOCATION),
-        CALCULATION_METHOD: config_entry.data.get(CALCULATION_METHOD),
     }
 
 
@@ -186,6 +189,7 @@ class MawaqeetFlowHandler(ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize flow."""
         self.user_data: dict[str, Any] = {}
+        self.calculation_method: str = str(CalculationMethod.MUSLIM_WORLD_LEAGUE)
 
     async def async_step_user(
         self,
@@ -198,10 +202,11 @@ class MawaqeetFlowHandler(ConfigFlow, domain=DOMAIN):
             )
             self._abort_if_unique_id_configured()
             self.user_data = user_input
-            return await self.async_step_adjustment()
+            self.context[CONF_LOCATION] = user_input[CONF_LOCATION]
+            return await self.async_step_calculation()
 
         data_schema = self.add_suggested_values_to_schema(
-            vol.Schema(DATA_SCHEMA), _get_data_schema(self.hass)
+            vol.Schema(LOCATION_SCHEMA), _get_location_schema(self.hass)
         )
 
         return self.async_show_form(
@@ -211,22 +216,49 @@ class MawaqeetFlowHandler(ConfigFlow, domain=DOMAIN):
             last_step=False,
         )
 
+    async def async_step_calculation(
+        self, user_input: dict | None = None
+    ) -> ConfigFlowResult:
+        """Select calculation method before adjustments."""
+        if user_input is not None:
+            self.calculation_method = user_input[CALCULATION_METHOD]
+            self.context[CALCULATION_METHOD] = self.calculation_method
+            return await self.async_step_adjustment()
+
+        data_schema = self.add_suggested_values_to_schema(
+            vol.Schema(METHOD_SCHEMA),
+            {CALCULATION_METHOD: str(CalculationMethod.MUSLIM_WORLD_LEAGUE)},
+        )
+        return self.async_show_form(
+            step_id="calculation",
+            data_schema=data_schema,
+            last_step=False,
+            preview=DOMAIN,
+        )
+
     async def async_step_adjustment(
         self, user_input: dict | None = None
     ) -> ConfigFlowResult:
         """Step adjustment."""
         if user_input is not None:
+            options = migrate_options(
+                {CALCULATION_METHOD: self.calculation_method, **user_input}
+            )
             return self.async_create_entry(
                 title=self.user_data[CONF_NAME],
                 data=self.user_data,
-                options=migrate_options(user_input),
+                options=options,
             )
 
-        data_schema = _build_adjustment_schema(self.user_data[CALCULATION_METHOD])
+        data_schema = _build_adjustment_schema(self.calculation_method)
         data_schema = self.add_suggested_values_to_schema(
             data_schema, DEFAULT_ADJUSTMENT_VALUES
         )
-        return self.async_show_form(step_id="adjustment", data_schema=data_schema)
+        return self.async_show_form(
+            step_id="adjustment",
+            data_schema=data_schema,
+            preview=DOMAIN,
+        )
 
     async def async_step_reconfigure(
         self, user_input: dict | None = None
@@ -248,10 +280,16 @@ class MawaqeetFlowHandler(ConfigFlow, domain=DOMAIN):
             )
 
         data_schema = self.add_suggested_values_to_schema(
-            vol.Schema(DATA_SCHEMA), _get_data_schema(self.hass, reconfigure_entry)
+            vol.Schema(LOCATION_SCHEMA),
+            _get_location_schema(self.hass, reconfigure_entry),
         )
 
         return self.async_show_form(step_id="reconfigure", data_schema=data_schema)
+
+    @staticmethod
+    async def async_setup_preview(hass: HomeAssistant) -> None:
+        """Set up preview WS API."""
+        await async_setup_preview(hass)
 
     @staticmethod
     @callback
@@ -265,23 +303,69 @@ class MawaqeetFlowHandler(ConfigFlow, domain=DOMAIN):
 class MawaqeetOptionsFlowHandler(OptionsFlowWithReload):
     """Options flow for Mawaqeet component."""
 
+    def __init__(self) -> None:
+        """Initialize options flow."""
+        self.calculation_method: str | None = None
+
+    @staticmethod
+    async def async_setup_preview(hass: HomeAssistant) -> None:
+        """Set up preview WS API."""
+        await async_setup_preview(hass)
+
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Configure options for Mawaqeet."""
-        return await self.async_step_adjustment(user_input)
+        return await self.async_step_calculation(user_input)
+
+    async def async_step_calculation(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Select calculation method before adjustments."""
+        if user_input is not None:
+            self.calculation_method = user_input[CALCULATION_METHOD]
+            self.context[CALCULATION_METHOD] = self.calculation_method
+            return await self.async_step_adjustment()
+
+        current_method = get_calculation_method(self.config_entry)
+        data_schema = self.add_suggested_values_to_schema(
+            vol.Schema(METHOD_SCHEMA),
+            {CALCULATION_METHOD: current_method},
+        )
+        return self.async_show_form(
+            step_id="calculation",
+            data_schema=data_schema,
+            last_step=False,
+            preview=DOMAIN,
+        )
 
     async def async_step_adjustment(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Configure adjustment options."""
-        if user_input is not None:
-            return self.async_create_entry(data=migrate_options(user_input))
+        calculation_method = self.calculation_method or get_calculation_method(
+            self.config_entry
+        )
+        self.context[CALCULATION_METHOD] = calculation_method
 
-        calculation_method = self.config_entry.data[CALCULATION_METHOD]
+        if user_input is not None:
+            return self.async_create_entry(
+                data=migrate_options(
+                    {
+                        **self.config_entry.options,
+                        CALCULATION_METHOD: calculation_method,
+                        **user_input,
+                    }
+                )
+            )
+
         data_schema = _build_adjustment_schema(calculation_method)
         data_schema = self.add_suggested_values_to_schema(
             data_schema, _merged_options(self.config_entry)
         )
 
-        return self.async_show_form(step_id="adjustment", data_schema=data_schema)
+        return self.async_show_form(
+            step_id="adjustment",
+            data_schema=data_schema,
+            preview=DOMAIN,
+        )

--- a/custom_components/mawaqeet/const.py
+++ b/custom_components/mawaqeet/const.py
@@ -31,3 +31,10 @@ HIGH_LATITUDE_RULE = "high_latitude_rule"
 REMINDER_ENABLED = "reminder_enabled"
 REMINDER_MINUTES = "reminder_minutes"  # legacy global fallback
 DEFAULT_REMINDER_MINUTES = 15
+
+# Defaults used when previewing the custom calculation method before angles are set.
+CUSTOM_PREVIEW_DEFAULTS = {
+    FAJR_ANGLE: 18.0,
+    ISHAA_ANGLE: 18.0,
+    ISHAA_INTERVAL: 0,
+}

--- a/custom_components/mawaqeet/coordinator.py
+++ b/custom_components/mawaqeet/coordinator.py
@@ -121,12 +121,14 @@ class MawaqeetDataUpdateCoordinator(DataUpdateCoordinator[MawaqeetData]):
         )
 
     def _async_fire_prayer_event(self, trigger_type: str, prayer: str) -> Any:
-        event_data = self._prayer_event_data(trigger_type, prayer)
+        """Return a callback that builds event data at fire time."""
 
         @callback
         def fire_event(dt: datetime) -> None:
             self.hass.bus.async_fire(
-                MAWAQEET_EVENT, event_data, time_fired=dt.timestamp()
+                MAWAQEET_EVENT,
+                self._prayer_event_data(trigger_type, prayer),
+                time_fired=dt.timestamp(),
             )
 
         return fire_event

--- a/custom_components/mawaqeet/diagnostics.py
+++ b/custom_components/mawaqeet/diagnostics.py
@@ -8,6 +8,7 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import CONF_LATITUDE, CONF_LOCATION, CONF_LONGITUDE
 
 from .enum import REMINDER_SCHEDULE_PRAYERS
+from .options import get_calculation_method
 
 if TYPE_CHECKING:
     from .data import MawaqeetConfigEntry
@@ -35,6 +36,7 @@ async def async_get_config_entry_diagnostics(
         "unique_id": entry.unique_id,
         "data": async_redact_data(dict(entry.data), TO_REDACT),
         "options": dict(entry.options),
+        "calculation_method": get_calculation_method(entry),
         "prayer_times": prayer_times,
         "prayer_times_config": dict(data["prayer_times_config"]) if data else {},
         "reminder_schedule_prayers": [str(p) for p in REMINDER_SCHEDULE_PRAYERS],

--- a/custom_components/mawaqeet/enum.py
+++ b/custom_components/mawaqeet/enum.py
@@ -36,7 +36,7 @@ class PrayerTimeOption(StrEnum):
 
     CALCULATION_METHOD = auto()
     MADHAB = auto()
-    NIGHT_LENGTH = auto()  # From Maghtib to Shuruq
+    NIGHT_LENGTH = auto()  # From Maghrib to Shuruq
     NIGHT_DURATION = auto()  # From Maghrib to Fajr
     HIGH_LATITUDE_RULE = auto()
     FAJR_ANGLE = auto()

--- a/custom_components/mawaqeet/event.py
+++ b/custom_components/mawaqeet/event.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
     from .coordinator import MawaqeetDataUpdateCoordinator
     from .data import MawaqeetConfigEntry
 
+PARALLEL_UPDATES = 1
+
 LATEST_PRAYER_TIME = "latest_prayer_time"
 LATEST_PRAYER_REMINDER = "latest_prayer_reminder"
 

--- a/custom_components/mawaqeet/frontend/src/entity-resolver.test.ts
+++ b/custom_components/mawaqeet/frontend/src/entity-resolver.test.ts
@@ -3,7 +3,9 @@ import {
   extractPrayerKey,
   findCurrentPrayer,
   findNextPrayer,
+  PRAYER_DEFAULT_ICONS,
   resolvePrayerEntities,
+  resolvePrayerIcon,
 } from "./entity-resolver";
 import type { HomeAssistant } from "./types";
 
@@ -84,15 +86,39 @@ describe("extractPrayerKey", () => {
       extractPrayerKey({
         entity_id: "sensor.foo_fajr",
         platform: "mawaqeet",
+        translation_key: "fajr",
       }),
     ).toBe("fajr");
+  });
+});
+
+describe("resolvePrayerIcon", () => {
+  it("prefers config override over attribute and default", () => {
+    expect(
+      resolvePrayerIcon("fajr", "mdi:weather-sunset-up", {
+        fajr: "mdi:mosque",
+      }),
+    ).toBe("mdi:mosque");
+  });
+
+  it("uses state attribute when no config override", () => {
+    expect(resolvePrayerIcon("dhuhr", "mdi:custom")).toBe("mdi:custom");
+  });
+
+  it("falls back to per-prayer default, not mosque", () => {
+    expect(resolvePrayerIcon("maghrib", undefined)).toBe(
+      PRAYER_DEFAULT_ICONS.maghrib,
+    );
+    expect(resolvePrayerIcon("midnight", undefined)).toBe(
+      PRAYER_DEFAULT_ICONS.midnight,
+    );
   });
 });
 
 describe("resolvePrayerEntities", () => {
   it("returns prayers sorted in canonical order", () => {
     const hass = mockHass(sixPrayerStates(), sixPrayerEntities());
-    const prayers = resolvePrayerEntities(hass, DEVICE, false);
+    const prayers = resolvePrayerEntities(hass, DEVICE);
     expect(prayers.map((p) => p.prayer_key)).toEqual([
       "fajr",
       "dhuhr",
@@ -100,6 +126,7 @@ describe("resolvePrayerEntities", () => {
       "maghrib",
       "ishaa",
     ]);
+    expect(prayers[0].icon).toBe(PRAYER_DEFAULT_ICONS.fajr);
   });
 
   it("includes shuruq when enabled", () => {
@@ -112,7 +139,7 @@ describe("resolvePrayerEntities", () => {
       "sensor.x_shuruq": { state: iso(6, 15) },
     };
     const hass = mockHass(states, entities);
-    const prayers = resolvePrayerEntities(hass, DEVICE, true);
+    const prayers = resolvePrayerEntities(hass, DEVICE, { showShuruq: true });
     expect(prayers.map((p) => p.prayer_key)).toEqual([
       "fajr",
       "shuruq",
@@ -123,16 +150,66 @@ describe("resolvePrayerEntities", () => {
     ]);
   });
 
+  it("includes midnight and last_third after ishaa when enabled", () => {
+    const entities = {
+      ...sixPrayerEntities(),
+      "sensor.x_midnight": { translation_key: "midnight" },
+      "sensor.x_last_third": { translation_key: "last_third" },
+    };
+    const states = {
+      ...sixPrayerStates(),
+      "sensor.x_midnight": { state: iso(0, 15) },
+      "sensor.x_last_third": { state: iso(2, 30) },
+    };
+    const hass = mockHass(states, entities);
+    const prayers = resolvePrayerEntities(hass, DEVICE, {
+      showMidnight: true,
+      showLastThird: true,
+    });
+    expect(prayers.map((p) => p.prayer_key)).toEqual([
+      "fajr",
+      "dhuhr",
+      "asr",
+      "maghrib",
+      "ishaa",
+      "midnight",
+      "last_third",
+    ]);
+  });
+
+  it("keeps core prayers when optional midnight sensor is missing", () => {
+    const hass = mockHass(sixPrayerStates(), sixPrayerEntities());
+    const prayers = resolvePrayerEntities(hass, DEVICE, {
+      showMidnight: true,
+    });
+    expect(prayers.map((p) => p.prayer_key)).toEqual([
+      "fajr",
+      "dhuhr",
+      "asr",
+      "maghrib",
+      "ishaa",
+    ]);
+  });
+
+  it("applies config icon overrides", () => {
+    const hass = mockHass(sixPrayerStates(), sixPrayerEntities());
+    const prayers = resolvePrayerEntities(hass, DEVICE, {}, { fajr: "mdi:star" });
+    expect(prayers.find((p) => p.prayer_key === "fajr")?.icon).toBe("mdi:star");
+    expect(prayers.find((p) => p.prayer_key === "dhuhr")?.icon).toBe(
+      PRAYER_DEFAULT_ICONS.dhuhr,
+    );
+  });
+
   it("returns empty for wrong device", () => {
     const hass = mockHass(sixPrayerStates(), sixPrayerEntities());
-    expect(resolvePrayerEntities(hass, "other", false)).toEqual([]);
+    expect(resolvePrayerEntities(hass, "other")).toEqual([]);
   });
 });
 
 describe("findNextPrayer", () => {
   it("picks earliest future prayer", () => {
     const hass = mockHass(sixPrayerStates(), sixPrayerEntities());
-    const prayers = resolvePrayerEntities(hass, DEVICE, false);
+    const prayers = resolvePrayerEntities(hass, DEVICE);
     const now = new Date(iso(13, 0));
     const next = findNextPrayer(prayers, now);
     expect(next?.prayer.prayer_key).toBe("asr");
@@ -141,7 +218,7 @@ describe("findNextPrayer", () => {
 
   it("wraps to fajr tomorrow when all passed", () => {
     const hass = mockHass(sixPrayerStates(), sixPrayerEntities());
-    const prayers = resolvePrayerEntities(hass, DEVICE, false);
+    const prayers = resolvePrayerEntities(hass, DEVICE);
     const now = new Date(iso(22, 0));
     const next = findNextPrayer(prayers, now);
     expect(next?.prayer.prayer_key).toBe("fajr");
@@ -152,7 +229,7 @@ describe("findNextPrayer", () => {
 describe("findCurrentPrayer", () => {
   it("returns last prayer at or before now", () => {
     const hass = mockHass(sixPrayerStates(), sixPrayerEntities());
-    const prayers = resolvePrayerEntities(hass, DEVICE, false);
+    const prayers = resolvePrayerEntities(hass, DEVICE);
     const now = new Date(iso(16, 0));
     expect(findCurrentPrayer(prayers, now)?.prayer_key).toBe("asr");
   });

--- a/custom_components/mawaqeet/frontend/src/entity-resolver.ts
+++ b/custom_components/mawaqeet/frontend/src/entity-resolver.ts
@@ -2,6 +2,8 @@ import {
   buildPrayerOrder,
   isPrayerKey,
   prayerSortIndex,
+  requiredPrayerCount,
+  type PrayerDisplayOptions,
   type PrayerKey,
 } from "./prayer-order";
 import type {
@@ -14,6 +16,33 @@ import type {
 const DOMAIN = "mawaqeet";
 const DEFAULT_ICON = "mdi:mosque";
 
+/** Defaults mirror custom_components/mawaqeet/icons.json entity icons. */
+export const PRAYER_DEFAULT_ICONS: Record<PrayerKey, string> = {
+  fajr: "mdi:weather-sunset-up",
+  shuruq: "mdi:weather-sunny",
+  dhuhr: "mdi:white-balance-sunny",
+  asr: "mdi:weather-partly-cloudy",
+  maghrib: "mdi:weather-sunset",
+  ishaa: "mdi:weather-night",
+  midnight: "mdi:clock-time-twelve",
+  last_third: "mdi:clock-outline",
+};
+
+export function resolvePrayerIcon(
+  key: PrayerKey,
+  stateIcon: string | undefined,
+  configIcons?: Partial<Record<PrayerKey, string>>,
+): string {
+  const override = configIcons?.[key];
+  if (override) {
+    return override;
+  }
+  if (stateIcon) {
+    return stateIcon;
+  }
+  return PRAYER_DEFAULT_ICONS[key] || DEFAULT_ICON;
+}
+
 export function extractPrayerKey(entry: EntityRegistryEntry): string | null {
   if (entry.translation_key) {
     return entry.translation_key;
@@ -25,13 +54,14 @@ export function extractPrayerKey(entry: EntityRegistryEntry): string | null {
 export function resolvePrayerEntities(
   hass: HomeAssistant,
   deviceId: string,
-  showShuruq: boolean,
+  options: PrayerDisplayOptions = {},
+  configIcons?: Partial<Record<PrayerKey, string>>,
 ): ResolvedPrayer[] {
   if (!deviceId || !hass.entities) {
     return [];
   }
 
-  const order = buildPrayerOrder(showShuruq);
+  const order = buildPrayerOrder(options);
   const resolved: ResolvedPrayer[] = [];
 
   for (const entry of Object.values(hass.entities)) {
@@ -43,7 +73,7 @@ export function resolvePrayerEntities(
     }
 
     const key = extractPrayerKey(entry);
-    if (!key || !isPrayerKey(key, showShuruq)) {
+    if (!key || !isPrayerKey(key, options)) {
       continue;
     }
 
@@ -66,7 +96,11 @@ export function resolvePrayerEntities(
       entity_id: entry.entity_id,
       prayer_key: key,
       label: formatPrayerLabel(hass, entry, state),
-      icon: (state.attributes.icon as string) || DEFAULT_ICON,
+      icon: resolvePrayerIcon(
+        key,
+        state.attributes.icon as string | undefined,
+        configIcons,
+      ),
       at,
       state,
     });
@@ -74,19 +108,22 @@ export function resolvePrayerEntities(
 
   resolved.sort(
     (a, b) =>
-      prayerSortIndex(a.prayer_key, showShuruq) -
-      prayerSortIndex(b.prayer_key, showShuruq),
+      prayerSortIndex(a.prayer_key, options) -
+      prayerSortIndex(b.prayer_key, options),
   );
 
-  const required = showShuruq ? 6 : CORE_PRAYER_COUNT;
-  if (resolved.length < required) {
+  const required = requiredPrayerCount(options);
+  const coreAndShuruq = resolved.filter((p) =>
+    (order as readonly string[])
+      .filter((k) => k !== "midnight" && k !== "last_third")
+      .includes(p.prayer_key),
+  );
+  if (coreAndShuruq.length < required) {
     return [];
   }
 
   return resolved;
 }
-
-const CORE_PRAYER_COUNT = 5;
 
 export interface NextPrayerInfo {
   prayer: ResolvedPrayer;
@@ -147,7 +184,7 @@ export function formatPrayerLabel(
       return localized;
     }
   }
-  return state.attributes.friendly_name as string || entry.entity_id;
+  return (state.attributes.friendly_name as string) || entry.entity_id;
 }
 
 export function formatTime(

--- a/custom_components/mawaqeet/frontend/src/grid-options.test.ts
+++ b/custom_components/mawaqeet/frontend/src/grid-options.test.ts
@@ -27,7 +27,7 @@ describe("gridOptionsForLayout", () => {
     expect(gridOptionsForLayout("timeline")).toEqual({
       columns: 12,
       rows: 3,
-      min_rows: 2,
+      min_rows: 3,
       max_rows: 4,
     });
   });

--- a/custom_components/mawaqeet/frontend/src/grid-options.ts
+++ b/custom_components/mawaqeet/frontend/src/grid-options.ts
@@ -15,7 +15,7 @@ export function gridOptionsForLayout(layout: CardLayout): LovelaceGridOptions {
       return {
         columns: 12,
         rows: 3,
-        min_rows: 2,
+        min_rows: 3,
         max_rows: 4,
       };
     case "vertical":

--- a/custom_components/mawaqeet/frontend/src/layouts/render.ts
+++ b/custom_components/mawaqeet/frontend/src/layouts/render.ts
@@ -35,7 +35,9 @@ export function renderError(message: string): TemplateResult {
 }
 
 function iconNode(icon: string): TemplateResult {
-  return html`<ha-icon .icon=${icon}></ha-icon>`;
+  return html`<span class="icon-slot" aria-hidden="true"
+    ><ha-icon .icon=${icon}></ha-icon
+  ></span>`;
 }
 
 function rowClick(
@@ -46,6 +48,40 @@ function rowClick(
     ev.stopPropagation();
     onTap(entityId);
   };
+}
+
+function rowKeydown(
+  entityId: string,
+  onTap: (entityId: string) => void,
+): (ev: KeyboardEvent) => void {
+  return (ev) => {
+    if (ev.key === "Enter" || ev.key === " ") {
+      ev.preventDefault();
+      ev.stopPropagation();
+      onTap(entityId);
+    }
+  };
+}
+
+function interactiveRow(
+  entityId: string,
+  onTap: (entityId: string) => void,
+  classes: string,
+  content: TemplateResult,
+  ariaLabel?: string,
+): TemplateResult {
+  return html`
+    <div
+      class=${classes}
+      @click=${rowClick(entityId, onTap)}
+      @keydown=${rowKeydown(entityId, onTap)}
+      role="button"
+      tabindex="0"
+      aria-label=${ariaLabel ?? nothing}
+    >
+      ${content}
+    </div>
+  `;
 }
 
 export function renderNext(
@@ -66,25 +102,28 @@ export function renderNext(
   const followingLabel =
     following &&
     html`Following: ${following.label} at ${formatTime(following.at, hass, tf)}`;
+  const ariaLabel = `Next prayer: ${prayer.label} ${countdown} at ${atLabel}`;
 
   return html`
     ${renderHeader(hass, config)}
-    <div
-      class="next-hero"
-      @click=${rowClick(prayer.entity_id, onTap)}
-      role="button"
-      tabindex="0"
-    >
-      ${iconNode(prayer.icon)}
-      <div class="prayer-name">${prayer.label}</div>
-      <div class="countdown">${countdown} · ${atLabel}</div>
-      ${isTomorrow
-        ? html`<div class="following">Tomorrow</div>`
-        : nothing}
-      ${followingLabel
-        ? html`<div class="following">${followingLabel}</div>`
-        : nothing}
-    </div>
+    ${interactiveRow(
+      prayer.entity_id,
+      onTap,
+      "next-hero",
+      html`
+        ${iconNode(prayer.icon)}
+        <div class="prayer-name">${prayer.label}</div>
+        <div class="countdown">${countdown}</div>
+        <div class="at-time">${atLabel}</div>
+        ${isTomorrow
+          ? html`<div class="tomorrow-badge">Tomorrow</div>`
+          : nothing}
+        ${followingLabel
+          ? html`<div class="following">${followingLabel}</div>`
+          : nothing}
+      `,
+      ariaLabel,
+    )}
   `;
 }
 
@@ -106,28 +145,28 @@ export function renderVertical(
       const isNext = p.entity_id === nextId;
       const isPassed =
         config.show_passed_style !== false && p.at.getTime() < now.getTime();
-      const classes = ["row", isNext ? "next" : "", isPassed ? "passed strike" : ""]
+      const classes = ["row", isNext ? "next" : "", isPassed ? "passed" : ""]
         .filter(Boolean)
         .join(" ");
-      return html`
-        <div
-          class=${classes}
-          @click=${rowClick(p.entity_id, onTap)}
-          role="button"
-          tabindex="0"
-        >
+      const timeLabel = formatTime(p.at, hass, tf);
+      return interactiveRow(
+        p.entity_id,
+        onTap,
+        classes,
+        html`
           ${iconNode(p.icon)}
           <span class="name">${p.label}</span>
           <span class="times">
-            <div>${formatTime(p.at, hass, tf)}</div>
+            <div>${timeLabel}</div>
             ${showRelative
               ? html`<div class="relative">
                   ${formatRelative(p.at, now)}
                 </div>`
               : nothing}
           </span>
-        </div>
-      `;
+        `,
+        `${p.label} ${timeLabel}`,
+      );
     })}
   `;
 }
@@ -154,23 +193,23 @@ export function renderHorizontal(
         const classes = ["chip", isNext ? "next" : "", isPassed ? "passed" : ""]
           .filter(Boolean)
           .join(" ");
-        return html`
-          <div
-            class=${classes}
-            @click=${rowClick(p.entity_id, onTap)}
-            role="button"
-            tabindex="0"
-          >
+        const timeLabel = formatTime(p.at, hass, tf);
+        return interactiveRow(
+          p.entity_id,
+          onTap,
+          classes,
+          html`
             ${iconNode(p.icon)}
             <div>${p.label}</div>
-            <div class="chip-time">${formatTime(p.at, hass, tf)}</div>
+            <div class="chip-time">${timeLabel}</div>
             ${showRelative
               ? html`<div class="chip-relative">
                   ${formatRelative(p.at, now)}
                 </div>`
               : nothing}
-          </div>
-        `;
+          `,
+          `${p.label} ${timeLabel}`,
+        );
       })}
     </div>
   `;
@@ -217,26 +256,33 @@ export function renderAgenda(
       const classes = ["row", isNext ? "next" : "", isPassed ? "passed" : ""]
         .filter(Boolean)
         .join(" ");
-      return html`
-        <div
-          class=${classes}
-          @click=${rowClick(p.entity_id, onTap)}
-          role="button"
-          tabindex="0"
-        >
-          ${isPassed ? html`<span class="agenda-check">✓</span>` : nothing}
+      const timeLabel = formatTime(p.at, hass, tf);
+      return interactiveRow(
+        p.entity_id,
+        onTap,
+        classes,
+        html`
+          <span class="agenda-status" aria-hidden="true">
+            ${isPassed
+              ? html`<ha-icon .icon=${"mdi:check"}></ha-icon>`
+              : nothing}
+          </span>
           ${iconNode(p.icon)}
           <span class="name">${p.label}</span>
-          <span class="times">${formatTime(p.at, hass, tf)}</span>
-        </div>
-      `;
+          <span class="times">${timeLabel}</span>
+        `,
+        `${p.label} ${timeLabel}`,
+      );
     })}
   `;
 
   return html`
     ${renderHeader(hass, config)}
     ${earlier.length ? renderSection("Earlier today", earlier) : nothing}
-    ${upcoming.length ? renderSection("Upcoming", upcoming) : renderSection("Upcoming", prayers)}
+    ${upcoming.length
+      ? renderSection("Upcoming", upcoming)
+      : html`<div class="section-title">Upcoming</div>
+          <div class="agenda-empty">All prayers complete for today</div>`}
   `;
 }
 
@@ -253,8 +299,13 @@ export function renderTimeline(
   const start = prayers[0].at.getTime();
   const end = prayers[prayers.length - 1].at.getTime();
   const span = end - start || 1;
-  const nowPct = Math.min(100, Math.max(0, ((now.getTime() - start) / span) * 100));
+  const nowPct = Math.min(
+    100,
+    Math.max(0, ((now.getTime() - start) / span) * 100),
+  );
   const tf = timeFmt(hass, config);
+  const nextInfo = findNextPrayer(prayers, now);
+  const nextId = nextInfo?.prayer.entity_id;
 
   return html`
     ${renderHeader(hass, config)}
@@ -263,17 +314,32 @@ export function renderTimeline(
       <div class="timeline-now" style="left: ${nowPct}%"></div>
       ${prayers.map((p) => {
         const left = ((p.at.getTime() - start) / span) * 100;
+        const isNext = p.entity_id === nextId;
+        const isPassed =
+          config.show_passed_style !== false && p.at.getTime() < now.getTime();
+        const classes = [
+          "timeline-marker",
+          isNext ? "next" : "",
+          isPassed ? "passed" : "",
+        ]
+          .filter(Boolean)
+          .join(" ");
+        const timeLabel = formatTime(p.at, hass, tf);
+        const label = `${p.label} ${timeLabel}`;
         return html`
           <div
-            class="timeline-marker"
+            class=${classes}
             style="left: ${left}%"
             @click=${rowClick(p.entity_id, onTap)}
+            @keydown=${rowKeydown(p.entity_id, onTap)}
             role="button"
             tabindex="0"
+            aria-label=${label}
+            title=${label}
           >
             ${iconNode(p.icon)}
             <div>${p.label}</div>
-            <div>${formatTime(p.at, hass, tf)}</div>
+            <div>${timeLabel}</div>
           </div>
         `;
       })}

--- a/custom_components/mawaqeet/frontend/src/mawaqeet-prayer-card.ts
+++ b/custom_components/mawaqeet/frontend/src/mawaqeet-prayer-card.ts
@@ -8,6 +8,7 @@ import type {
   HomeAssistant,
   LovelaceGridOptions,
   MawaqeetCardConfig,
+  PrayerKey,
 } from "./types";
 
 declare global {
@@ -43,6 +44,8 @@ export class MawaqeetPrayerCard extends LitElement {
       type: "custom:mawaqeet-prayer-card",
       layout: "next",
       show_shuruq: false,
+      show_midnight: false,
+      show_last_third: false,
       show_passed_style: true,
       time_format: "system",
       show_relative: true,
@@ -81,6 +84,8 @@ export class MawaqeetPrayerCard extends LitElement {
       type: "custom:mawaqeet-prayer-card",
       layout: "next",
       show_shuruq: false,
+      show_midnight: false,
+      show_last_third: false,
     };
   }
 
@@ -109,11 +114,16 @@ export class MawaqeetPrayerCard extends LitElement {
       return html`<ha-card><div class="error">Loading…</div></ha-card>`;
     }
 
-    const showShuruq = this._config.show_shuruq === true;
+    const displayOptions = {
+      showShuruq: this._config.show_shuruq === true,
+      showMidnight: this._config.show_midnight === true,
+      showLastThird: this._config.show_last_third === true,
+    };
     const prayers = resolvePrayerEntities(
       this.hass,
       this._config.device!,
-      showShuruq,
+      displayOptions,
+      this._config.icons,
     );
 
     let body;
@@ -148,46 +158,93 @@ export class MawaqeetPrayerCard extends LitElement {
   }
 }
 
-const EDITOR_SCHEMA = [
-  {
-    name: "device",
-    required: true,
-    selector: {
-      device: { filter: { integration: "mawaqeet" } },
-    },
-  },
-  {
-    name: "layout",
-    selector: {
-      select: {
-        options: [
-          { value: "next", label: "Next prayer" },
-          { value: "horizontal", label: "Horizontal timetable" },
-          { value: "vertical", label: "Vertical timetable" },
-          { value: "combined", label: "Combined (next + horizontal)" },
-          { value: "timeline", label: "Day timeline" },
-          { value: "agenda", label: "Agenda" },
-        ],
+type HaFormSchema = Record<string, unknown> & { name: string };
+
+function buildEditorSchema(config: MawaqeetCardConfig): HaFormSchema[] {
+  const iconFields: HaFormSchema[] = [
+    { name: "fajr", selector: { icon: {} } },
+  ];
+  if (config.show_shuruq) {
+    iconFields.push({ name: "shuruq", selector: { icon: {} } });
+  }
+  iconFields.push(
+    { name: "dhuhr", selector: { icon: {} } },
+    { name: "asr", selector: { icon: {} } },
+    { name: "maghrib", selector: { icon: {} } },
+    { name: "ishaa", selector: { icon: {} } },
+  );
+  if (config.show_midnight) {
+    iconFields.push({ name: "midnight", selector: { icon: {} } });
+  }
+  if (config.show_last_third) {
+    iconFields.push({ name: "last_third", selector: { icon: {} } });
+  }
+
+  return [
+    {
+      name: "device",
+      required: true,
+      selector: {
+        device: { filter: { integration: "mawaqeet" } },
       },
     },
-  },
-  { name: "show_shuruq", selector: { boolean: {} } },
-  { name: "show_passed_style", selector: { boolean: {} } },
-  {
-    name: "time_format",
-    selector: {
-      select: {
-        options: [
-          { value: "system", label: "System" },
-          { value: "24", label: "24-hour" },
-          { value: "12", label: "12-hour" },
-        ],
+    {
+      name: "layout",
+      selector: {
+        select: {
+          options: [
+            { value: "next", label: "Next prayer" },
+            { value: "horizontal", label: "Horizontal timetable" },
+            { value: "vertical", label: "Vertical timetable" },
+            { value: "combined", label: "Combined (next + horizontal)" },
+            { value: "timeline", label: "Day timeline" },
+            { value: "agenda", label: "Agenda" },
+          ],
+        },
       },
     },
-  },
-  { name: "show_relative", selector: { boolean: {} } },
-  { name: "show_device_name", selector: { boolean: {} } },
-];
+    { name: "show_shuruq", selector: { boolean: {} } },
+    { name: "show_midnight", selector: { boolean: {} } },
+    { name: "show_last_third", selector: { boolean: {} } },
+    { name: "show_passed_style", selector: { boolean: {} } },
+    {
+      name: "time_format",
+      selector: {
+        select: {
+          options: [
+            { value: "system", label: "System" },
+            { value: "24", label: "24-hour" },
+            { value: "12", label: "12-hour" },
+          ],
+        },
+      },
+    },
+    { name: "show_relative", selector: { boolean: {} } },
+    { name: "show_device_name", selector: { boolean: {} } },
+    {
+      name: "icons",
+      type: "expandable",
+      title: "Custom prayer icons",
+      schema: iconFields,
+      expanded: false,
+    },
+  ];
+}
+
+function sanitizeIcons(
+  icons: Partial<Record<PrayerKey, string>> | undefined,
+): Partial<Record<PrayerKey, string>> | undefined {
+  if (!icons) {
+    return undefined;
+  }
+  const cleaned: Partial<Record<PrayerKey, string>> = {};
+  for (const [key, value] of Object.entries(icons)) {
+    if (typeof value === "string" && value.trim()) {
+      cleaned[key as PrayerKey] = value.trim();
+    }
+  }
+  return Object.keys(cleaned).length ? cleaned : undefined;
+}
 
 @customElement("mawaqeet-prayer-card-editor")
 export class MawaqeetPrayerCardEditor extends LitElement {
@@ -207,7 +264,7 @@ export class MawaqeetPrayerCardEditor extends LitElement {
       <ha-form
         .hass=${this.hass}
         .data=${this._config}
-        .schema=${EDITOR_SCHEMA}
+        .schema=${buildEditorSchema(this._config)}
         .computeLabel=${(schema: { name: string }) =>
           EDITOR_LABELS[schema.name] ?? schema.name}
         @value-changed=${this._changed}
@@ -217,7 +274,14 @@ export class MawaqeetPrayerCardEditor extends LitElement {
 
   private _changed(ev: CustomEvent): void {
     ev.stopPropagation();
-    const config = ev.detail.value as MawaqeetCardConfig;
+    const value = ev.detail.value as MawaqeetCardConfig;
+    const icons = sanitizeIcons(value.icons);
+    const config: MawaqeetCardConfig = { ...value };
+    if (icons) {
+      config.icons = icons;
+    } else {
+      delete config.icons;
+    }
     this._config = config;
     const event = new CustomEvent("config-changed", {
       detail: { config },
@@ -232,10 +296,21 @@ const EDITOR_LABELS: Record<string, string> = {
   device: "Mawaqeet location",
   layout: "Layout",
   show_shuruq: "Show Shuruq (sunrise)",
+  show_midnight: "Show Midnight",
+  show_last_third: "Show Last Third",
   show_passed_style: "Dim passed prayers",
   time_format: "Time format",
   show_relative: "Show relative times",
   show_device_name: "Show location name",
+  icons: "Custom prayer icons",
+  fajr: "Fajr",
+  shuruq: "Shuruq",
+  dhuhr: "Dhuhr",
+  asr: "Asr",
+  maghrib: "Maghrib",
+  ishaa: "Ishaa",
+  midnight: "Midnight",
+  last_third: "Last Third",
 };
 
 if (typeof window !== "undefined") {

--- a/custom_components/mawaqeet/frontend/src/prayer-order.ts
+++ b/custom_components/mawaqeet/frontend/src/prayer-order.ts
@@ -9,11 +9,8 @@ export const CORE_PRAYER_KEYS = [
 ] as const;
 
 export const SHURUQ_KEY = "shuruq" as const;
-
-export const EXCLUDED_PRAYER_KEYS = new Set([
-  "midnight",
-  "last_third",
-]);
+export const MIDNIGHT_KEY = "midnight" as const;
+export const LAST_THIRD_KEY = "last_third" as const;
 
 export const DIAGNOSTIC_SENSOR_KEYS = new Set([
   "calculation_method",
@@ -34,25 +31,52 @@ export const DIAGNOSTIC_SENSOR_KEYS = new Set([
 
 export type PrayerKey =
   | (typeof CORE_PRAYER_KEYS)[number]
-  | typeof SHURUQ_KEY;
+  | typeof SHURUQ_KEY
+  | typeof MIDNIGHT_KEY
+  | typeof LAST_THIRD_KEY;
 
-export function buildPrayerOrder(showShuruq: boolean): PrayerKey[] {
-  if (!showShuruq) {
-    return [...CORE_PRAYER_KEYS];
-  }
-  return ["fajr", SHURUQ_KEY, "dhuhr", "asr", "maghrib", "ishaa"];
+export interface PrayerDisplayOptions {
+  showShuruq?: boolean;
+  showMidnight?: boolean;
+  showLastThird?: boolean;
 }
 
-export function isPrayerKey(key: string, showShuruq: boolean): key is PrayerKey {
-  if (EXCLUDED_PRAYER_KEYS.has(key) || DIAGNOSTIC_SENSOR_KEYS.has(key)) {
+export function buildPrayerOrder(options: PrayerDisplayOptions = {}): PrayerKey[] {
+  const order: PrayerKey[] = ["fajr"];
+  if (options.showShuruq) {
+    order.push(SHURUQ_KEY);
+  }
+  order.push("dhuhr", "asr", "maghrib", "ishaa");
+  if (options.showMidnight) {
+    order.push(MIDNIGHT_KEY);
+  }
+  if (options.showLastThird) {
+    order.push(LAST_THIRD_KEY);
+  }
+  return order;
+}
+
+/** Core five always required; Shuruq is required when enabled. Night extras are optional. */
+export function requiredPrayerCount(options: PrayerDisplayOptions = {}): number {
+  return 5 + (options.showShuruq ? 1 : 0);
+}
+
+export function isPrayerKey(
+  key: string,
+  options: PrayerDisplayOptions = {},
+): key is PrayerKey {
+  if (DIAGNOSTIC_SENSOR_KEYS.has(key)) {
     return false;
   }
-  const order = buildPrayerOrder(showShuruq);
+  const order = buildPrayerOrder(options);
   return (order as readonly string[]).includes(key);
 }
 
-export function prayerSortIndex(key: PrayerKey, showShuruq: boolean): number {
-  const order = buildPrayerOrder(showShuruq);
+export function prayerSortIndex(
+  key: PrayerKey,
+  options: PrayerDisplayOptions = {},
+): number {
+  const order = buildPrayerOrder(options);
   const index = order.indexOf(key);
   return index === -1 ? 999 : index;
 }

--- a/custom_components/mawaqeet/frontend/src/styles.ts
+++ b/custom_components/mawaqeet/frontend/src/styles.ts
@@ -17,7 +17,7 @@ export const cardStyles = css`
   .header {
     font-size: 0.85em;
     opacity: 0.7;
-    margin-bottom: 12px;
+    margin-bottom: 8px;
   }
 
   .error {
@@ -25,11 +25,18 @@ export const cardStyles = css`
     padding: 8px 0;
   }
 
+  .icon-slot {
+    width: 24px;
+    flex-shrink: 0;
+    display: grid;
+    place-items: center;
+  }
+
   .row {
     display: flex;
     align-items: center;
-    gap: 12px;
-    padding: 8px 4px;
+    gap: 10px;
+    padding: 6px 4px;
     border-radius: 8px;
     cursor: pointer;
   }
@@ -41,20 +48,26 @@ export const cardStyles = css`
   .row.next {
     font-weight: 600;
     background: rgba(var(--rgb-primary-color, 3, 169, 244), 0.12);
+    box-shadow: inset 3px 0 0 var(--primary-color);
   }
 
-  .row.passed {
-    opacity: 0.45;
+  .row.passed,
+  .chip.passed,
+  .timeline-marker.passed {
+    opacity: 0.6;
+    color: var(--secondary-text-color);
   }
 
-  .row.passed.strike {
-    text-decoration: line-through;
+  .row.passed ha-icon,
+  .chip.passed ha-icon,
+  .timeline-marker.passed ha-icon {
+    color: var(--secondary-text-color);
   }
 
-  .row ha-icon {
+  .row ha-icon,
+  .chip ha-icon {
     --mdc-icon-size: 22px;
     color: var(--primary-color);
-    flex-shrink: 0;
   }
 
   .row .name {
@@ -75,10 +88,16 @@ export const cardStyles = css`
   .next-hero {
     text-align: center;
     padding: 8px 0 16px;
+    cursor: pointer;
+  }
+
+  .next-hero .icon-slot {
+    width: auto;
+    margin: 0 auto;
   }
 
   .next-hero ha-icon {
-    --mdc-icon-size: 48px;
+    --mdc-icon-size: 40px;
     color: var(--primary-color);
   }
 
@@ -89,8 +108,26 @@ export const cardStyles = css`
   }
 
   .next-hero .countdown {
-    font-size: 1.25em;
+    font-size: 1.35em;
     color: var(--primary-color);
+    font-weight: 600;
+  }
+
+  .next-hero .at-time {
+    font-size: 0.95em;
+    opacity: 0.75;
+    margin-top: 2px;
+  }
+
+  .next-hero .tomorrow-badge {
+    display: inline-block;
+    margin-top: 8px;
+    padding: 2px 10px;
+    border-radius: 999px;
+    font-size: 0.75em;
+    font-weight: 600;
+    color: var(--primary-color);
+    background: rgba(var(--rgb-primary-color, 3, 169, 244), 0.12);
   }
 
   .next-hero .following {
@@ -111,11 +148,12 @@ export const cardStyles = css`
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 8px 10px;
+    padding: 8px 8px;
     border-radius: 8px;
     min-width: 4.5em;
     border: 1px solid transparent;
     cursor: pointer;
+    gap: 2px;
   }
 
   .chip.next {
@@ -124,18 +162,9 @@ export const cardStyles = css`
     font-weight: 600;
   }
 
-  .chip.passed {
-    opacity: 0.45;
-  }
-
-  .chip ha-icon {
-    --mdc-icon-size: 20px;
-    color: var(--primary-color);
-  }
-
   .chip .chip-time {
     font-size: 0.95em;
-    margin-top: 4px;
+    margin-top: 2px;
   }
 
   .chip .chip-relative {
@@ -152,14 +181,34 @@ export const cardStyles = css`
   .section-title {
     font-size: 0.75em;
     text-transform: uppercase;
+    letter-spacing: 0.04em;
     opacity: 0.6;
-    margin: 8px 0 4px;
+    margin: 12px 0 6px;
+  }
+
+  .agenda-empty {
+    font-size: 0.9em;
+    opacity: 0.65;
+    padding: 4px 0 8px;
+  }
+
+  .agenda-status {
+    width: 20px;
+    flex-shrink: 0;
+    display: grid;
+    place-items: center;
+    color: var(--secondary-text-color);
+  }
+
+  .agenda-status ha-icon {
+    --mdc-icon-size: 18px;
+    color: var(--secondary-text-color);
   }
 
   .timeline {
     position: relative;
-    height: 48px;
-    margin: 24px 8px 32px;
+    height: 80px;
+    margin: 28px 12px 36px;
   }
 
   .timeline-track {
@@ -178,27 +227,36 @@ export const cardStyles = css`
     top: 0;
     transform: translateX(-50%);
     text-align: center;
-    font-size: 0.65em;
+    font-size: 0.72em;
     white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .timeline-marker .icon-slot {
+    width: auto;
+    margin: 0 auto;
   }
 
   .timeline-marker ha-icon {
-    --mdc-icon-size: 16px;
+    --mdc-icon-size: 18px;
     color: var(--primary-color);
+  }
+
+  .timeline-marker.next {
+    font-weight: 600;
+  }
+
+  .timeline-marker.next ha-icon {
+    --mdc-icon-size: 20px;
   }
 
   .timeline-now {
     position: absolute;
     top: -4px;
     width: 2px;
-    height: 56px;
+    height: 88px;
     background: var(--accent-color, var(--primary-color));
     transform: translateX(-50%);
     z-index: 1;
-  }
-
-  .agenda-check {
-    opacity: 0.5;
-    margin-inline-end: 4px;
   }
 `;

--- a/custom_components/mawaqeet/frontend/src/types.ts
+++ b/custom_components/mawaqeet/frontend/src/types.ts
@@ -1,5 +1,9 @@
 /** Minimal Home Assistant types for the Lovelace card (no runtime HA dependency). */
 
+import type { PrayerKey } from "./prayer-order";
+
+export type { PrayerKey };
+
 export interface HomeAssistant {
   states: Record<string, HassEntity>;
   entities: Record<string, EntityRegistryEntry>;
@@ -59,10 +63,14 @@ export interface MawaqeetCardConfig {
   device?: string;
   layout?: CardLayout;
   show_shuruq?: boolean;
+  show_midnight?: boolean;
+  show_last_third?: boolean;
   show_passed_style?: boolean;
   time_format?: TimeFormat;
   show_relative?: boolean;
   show_device_name?: boolean;
+  /** Per-prayer MDI icon overrides; empty/omit uses defaults. */
+  icons?: Partial<Record<PrayerKey, string>>;
   tap_action?: { action: string };
 }
 
@@ -74,5 +82,3 @@ export interface ResolvedPrayer {
   at: Date;
   state: HassEntity;
 }
-
-export type { PrayerKey } from "./prayer-order";

--- a/custom_components/mawaqeet/manifest.json
+++ b/custom_components/mawaqeet/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "adhanpy==1.0.5"
   ],
-  "version": "0.4.0"
+  "version": "0.4.3"
 }

--- a/custom_components/mawaqeet/manifest.json
+++ b/custom_components/mawaqeet/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "adhanpy==1.0.5"
   ],
-  "version": "0.4.3"
+  "version": "0.4.4"
 }

--- a/custom_components/mawaqeet/mapper.py
+++ b/custom_components/mawaqeet/mapper.py
@@ -55,9 +55,6 @@ class CalculationMethodMapper:
 
         calc_method_params = calc_method_params.copy()
 
-        if calc_method_params is None:
-            return calculation_parameters
-
         if (method_adj := calc_method_params.get(METHOD_ADJUSTMENTS)) is not None:
             method_adj = PrayerAdjustments(**method_adj)
             calculation_parameters[ADHANPY_METHOD_ADJUSTMENTS] = (

--- a/custom_components/mawaqeet/options.py
+++ b/custom_components/mawaqeet/options.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from .const import CALCULATION_METHOD, DEFAULT_REMINDER_MINUTES, REMINDER_MINUTES
+from .const import (
+    CALCULATION_METHOD,
+    DEFAULT_REMINDER_MINUTES,
+    FAJR_ANGLE,
+    ISHAA_ANGLE,
+    ISHAA_INTERVAL,
+    REMINDER_MINUTES,
+)
 from .enum import (
     REMINDER_SCHEDULE_PRAYERS,
     CalculationMethod,
@@ -12,18 +19,24 @@ from .enum import (
 )
 
 if TYPE_CHECKING:
-    from .data import MawaqeetConfigEntry
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+
+CUSTOM_ONLY_OPTION_KEYS = (FAJR_ANGLE, ISHAA_ANGLE, ISHAA_INTERVAL)
 
 
-def get_calculation_method(config_entry: MawaqeetConfigEntry) -> str:
-    """Return the calculation method id from config entry data."""
-    return config_entry.data.get(
-        CALCULATION_METHOD, str(CalculationMethod.MUSLIM_WORLD_LEAGUE)
+def get_calculation_method(config_entry: ConfigEntry) -> str:
+    """Return the calculation method id from options, with legacy data fallback."""
+    return config_entry.options.get(
+        CALCULATION_METHOD,
+        config_entry.data.get(
+            CALCULATION_METHOD, str(CalculationMethod.MUSLIM_WORLD_LEAGUE)
+        ),
     )
 
 
 def migrate_options(options: dict[str, Any]) -> dict[str, Any]:
-    """Migrate legacy global reminder_minutes to per-prayer keys."""
+    """Migrate reminders and strip custom-only keys for preset methods."""
     migrated = dict(options)
     legacy_minutes = migrated.get(REMINDER_MINUTES)
     changed = False
@@ -41,6 +54,11 @@ def migrate_options(options: dict[str, Any]) -> dict[str, Any]:
     if changed and REMINDER_MINUTES in migrated:
         del migrated[REMINDER_MINUTES]
 
+    method = migrated.get(CALCULATION_METHOD)
+    if method is not None and method != str(CalculationMethod.CUSTOM):
+        for key in CUSTOM_ONLY_OPTION_KEYS:
+            migrated.pop(key, None)
+
     return migrated
 
 
@@ -51,4 +69,29 @@ def options_need_migration(options: dict[str, Any]) -> bool:
     return any(
         prayer_reminder_minutes_key(prayer) not in options
         for prayer in REMINDER_SCHEDULE_PRAYERS
+    )
+
+
+def calculation_method_needs_migration(config_entry: ConfigEntry) -> bool:
+    """Return True if calculation_method is still present in entry data."""
+    return CALCULATION_METHOD in config_entry.data
+
+
+def migrate_calculation_method(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+    """Move calculation method from entry data into options and strip data."""
+    if not calculation_method_needs_migration(config_entry):
+        return
+
+    method = config_entry.data[CALCULATION_METHOD]
+    new_data = {
+        key: value
+        for key, value in config_entry.data.items()
+        if key != CALCULATION_METHOD
+    }
+    new_options = dict(config_entry.options)
+    if CALCULATION_METHOD not in new_options:
+        new_options[CALCULATION_METHOD] = method
+    new_options = migrate_options(new_options)
+    hass.config_entries.async_update_entry(
+        config_entry, data=new_data, options=new_options
     )

--- a/custom_components/mawaqeet/preview.py
+++ b/custom_components/mawaqeet/preview.py
@@ -1,0 +1,199 @@
+"""Config and options flow prayer-time preview (websocket)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+from homeassistant.components import websocket_api
+from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_ICON, CONF_LOCATION
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.util import dt as dt_util
+
+from .calculation import compute_prayer_times_from_options
+from .const import (
+    CALCULATION_METHOD,
+    CUSTOM_PREVIEW_DEFAULTS,
+    DOMAIN,
+    MADHAB,
+)
+from .enum import CalculationMethod, Madhab, PrayerTime, PrayerTimeOption
+from .options import get_calculation_method
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from datetime import datetime
+
+    from homeassistant.components.websocket_api import ActiveConnection
+    from homeassistant.core import HomeAssistant
+
+PREVIEW_PRAYERS: tuple[PrayerTime, ...] = (
+    PrayerTime.FAJR,
+    PrayerTime.SHURUQ,
+    PrayerTime.DHUHR,
+    PrayerTime.ASR,
+    PrayerTime.MAGHRIB,
+    PrayerTime.ISHAA,
+)
+
+_PREVIEW_TITLES: dict[PrayerTime, str] = {
+    PrayerTime.FAJR: "Fajr",
+    PrayerTime.SHURUQ: "Shuruq",
+    PrayerTime.DHUHR: "Dhuhr",
+    PrayerTime.ASR: "Asr",
+    PrayerTime.MAGHRIB: "Maghrib",
+    PrayerTime.ISHAA: "Ishaa",
+}
+
+
+def format_preview_state(prayer_times: Mapping[PrayerTime, datetime]) -> str:
+    """Format today's prayer times as a compact single-row schedule."""
+    parts: list[str] = []
+    for prayer in PREVIEW_PRAYERS:
+        when = prayer_times[prayer]
+        local = dt_util.as_local(when)
+        parts.append(f"{_PREVIEW_TITLES[prayer]} {local.strftime('%H:%M')}")
+    return " · ".join(parts)
+
+
+def _preview_attributes(
+    data: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build attributes for the generic entity preview row."""
+    prayer_times: Mapping[PrayerTime, datetime] = data["prayer_times"]
+    config = data["prayer_times_config"]
+    attributes: dict[str, Any] = {
+        ATTR_FRIENDLY_NAME: "Today's prayer times",
+        ATTR_ICON: "mdi:mosque",
+        CALCULATION_METHOD: config[PrayerTimeOption.CALCULATION_METHOD],
+        MADHAB: config[PrayerTimeOption.MADHAB],
+    }
+    for prayer in PREVIEW_PRAYERS:
+        attributes[str(prayer)] = dt_util.as_local(prayer_times[prayer]).isoformat()
+    return attributes
+
+
+def _ensure_custom_angle_defaults(options: dict[str, Any]) -> dict[str, Any]:
+    """Seed custom angles when previewing custom before the adjustment step."""
+    if options.get(CALCULATION_METHOD) != str(CalculationMethod.CUSTOM):
+        return options
+    seeded = dict(options)
+    for key, value in CUSTOM_PREVIEW_DEFAULTS.items():
+        seeded.setdefault(key, value)
+    return seeded
+
+
+def _merge_preview_params(
+    hass: HomeAssistant,
+    flow_type: str,
+    flow_id: str,
+    user_input: dict[str, Any],
+) -> tuple[dict[str, float], dict[str, Any]]:
+    """Resolve location + options for the current preview subscription."""
+    if flow_type == "config_flow":
+        flow = hass.config_entries.flow.async_get(flow_id)
+        context = flow["context"]
+        location = context.get(CONF_LOCATION)
+        if not location:
+            msg = "Location not available for preview"
+            raise HomeAssistantError(msg)
+
+        step_id = flow.get("step_id")
+        options: dict[str, Any] = {
+            MADHAB: str(Madhab.SHAFI),
+            CALCULATION_METHOD: context.get(
+                CALCULATION_METHOD, str(CalculationMethod.MUSLIM_WORLD_LEAGUE)
+            ),
+        }
+        if step_id == "calculation":
+            options[CALCULATION_METHOD] = user_input.get(
+                CALCULATION_METHOD, options[CALCULATION_METHOD]
+            )
+        else:
+            options.update(user_input)
+            options[CALCULATION_METHOD] = context.get(
+                CALCULATION_METHOD, options[CALCULATION_METHOD]
+            )
+        return location, _ensure_custom_angle_defaults(options)
+
+    if flow_type == "options_flow":
+        flow = hass.config_entries.options.async_get(flow_id)
+        config_entry = hass.config_entries.async_get_entry(flow["handler"])
+        if config_entry is None:
+            msg = "Config entry not found"
+            raise HomeAssistantError(msg)
+
+        location = config_entry.data.get(CONF_LOCATION)
+        if not location:
+            msg = "Location not available for preview"
+            raise HomeAssistantError(msg)
+
+        step_id = flow.get("step_id")
+        options = dict(config_entry.options)
+        if step_id == "calculation":
+            options[CALCULATION_METHOD] = user_input.get(
+                CALCULATION_METHOD, get_calculation_method(config_entry)
+            )
+        else:
+            options.update(user_input)
+            options[CALCULATION_METHOD] = flow["context"].get(
+                CALCULATION_METHOD,
+                options.get(CALCULATION_METHOD, get_calculation_method(config_entry)),
+            )
+        return location, _ensure_custom_angle_defaults(options)
+
+    msg = f"Unsupported flow type: {flow_type}"
+    raise HomeAssistantError(msg)
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): f"{DOMAIN}/start_preview",
+        vol.Required("flow_id"): str,
+        vol.Required("flow_type"): vol.Any("config_flow", "options_flow"),
+        vol.Required("user_input"): dict,
+    }
+)
+@websocket_api.async_response
+async def ws_start_preview(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Generate a live prayer-times preview for config or options flows."""
+    try:
+        location, options = _merge_preview_params(
+            hass, msg["flow_type"], msg["flow_id"], msg["user_input"]
+        )
+        data = await hass.async_add_executor_job(
+            compute_prayer_times_from_options, location, options
+        )
+    except Exception as err:  # noqa: BLE001 - surface as preview error
+        error_message = str(err)
+        connection.send_result(msg["id"])
+        connection.send_message(
+            websocket_api.event_message(msg["id"], {"error": error_message})
+        )
+        connection.subscriptions[msg["id"]] = lambda: None
+        return
+
+    state = format_preview_state(data["prayer_times"])
+    attributes = _preview_attributes(data)
+
+    connection.send_result(msg["id"])
+    connection.send_message(
+        websocket_api.event_message(
+            msg["id"],
+            {"state": state, "attributes": attributes},
+        )
+    )
+    connection.subscriptions[msg["id"]] = lambda: None
+
+
+async def async_setup_preview(hass: HomeAssistant) -> None:
+    """Register the preview websocket command once per hass instance."""
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    if domain_data.get("preview_registered"):
+        return
+    websocket_api.async_register_command(hass, ws_start_preview)
+    domain_data["preview_registered"] = True

--- a/custom_components/mawaqeet/sensor.py
+++ b/custom_components/mawaqeet/sensor.py
@@ -23,6 +23,8 @@ if TYPE_CHECKING:
     from .coordinator import MawaqeetDataUpdateCoordinator
     from .data import MawaqeetConfigEntry
 
+PARALLEL_UPDATES = 1
+
 ENTITY_DESCRIPTIONS = (
     SensorEntityDescription(
         key=PrayerTime.FAJR,

--- a/custom_components/mawaqeet/translations/ar.json
+++ b/custom_components/mawaqeet/translations/ar.json
@@ -7,21 +7,31 @@
                 "description": "للمساعدة في الإعداد، راجع {documentation_url}",
                 "data_description": {
                     "name": "اسم هذا الموقع في Home Assistant.",
-                    "location": "الموقع على الخريطة لحساب أوقات الصلاة.",
-                    "calculation_method": "طريقة الحساب المناسبة لمنطقتك."
+                    "location": "الموقع على الخريطة لحساب أوقات الصلاة."
                 },
                 "data": {
                     "name": "الاسم",
                     "latitude": "خط العرض",
                     "longitude": "خط الطول",
-                    "location": "الموقع",
+                    "location": "الموقع"
+                }
+            },
+            "calculation": {
+                "title": "طريقة الحساب",
+                "description": "تُحدَّث المعاينة أدناه عند تغيير الطريقة. الأوقات لليوم في هذا الموقع.",
+                "data": {
                     "calculation_method": "طريقة الحساب"
+                },
+                "data_description": {
+                    "calculation_method": "طريقة الحساب المناسبة لمنطقتك."
                 }
             },
             "adjustment": {
                 "title": "تعديلات الصلاة",
+                "description": "تُحدَّث المعاينة أدناه عند تغيير المذهب أو التعديلات. إعدادات التذكير لا تغيّر المعاينة. الأوقات لليوم في هذا الموقع.",
                 "data_description": {
                     "madhab": "يؤثر على حساب العصر (شافعي أو حنفي).",
+                    "high_latitude_rule": "كيفية تعديل الفجر والعشاء قرب القطبين.",
                     "reminder_enabled": "إطلاق أحداث تذكير قبل كل صلاة.",
                     "fajr_reminder_minutes": "دقائق قبل الفجر لإطلاق حدث التذكير.",
                     "shuruq_reminder_minutes": "دقائق قبل الشروق لإطلاق حدث التذكير.",
@@ -55,13 +65,11 @@
                 "title": "إعادة إعداد مواقيت",
                 "data_description": {
                     "name": "اسم هذا الموقع في Home Assistant.",
-                    "location": "الموقع على الخريطة لحساب أوقات الصلاة.",
-                    "calculation_method": "طريقة الحساب المناسبة لمنطقتك."
+                    "location": "الموقع على الخريطة لحساب أوقات الصلاة."
                 },
                 "data": {
                     "name": "الاسم",
-                    "location": "الموقع",
-                    "calculation_method": "طريقة الحساب"
+                    "location": "الموقع"
                 }
             }
         },
@@ -78,10 +86,22 @@
     "options": {
         "flow_title": "خيارات مواقيت",
         "step": {
+            "calculation": {
+                "title": "طريقة الحساب",
+                "description": "تُحدَّث المعاينة أدناه عند تغيير الطريقة. الأوقات لليوم في هذا الموقع.",
+                "data": {
+                    "calculation_method": "طريقة الحساب"
+                },
+                "data_description": {
+                    "calculation_method": "طريقة الحساب المناسبة لمنطقتك."
+                }
+            },
             "adjustment": {
                 "title": "تعديلات الصلاة",
+                "description": "تُحدَّث المعاينة أدناه عند تغيير المذهب أو التعديلات. إعدادات التذكير لا تغيّر المعاينة. الأوقات لليوم في هذا الموقع.",
                 "data_description": {
                     "madhab": "يؤثر على حساب العصر (شافعي أو حنفي).",
+                    "high_latitude_rule": "كيفية تعديل الفجر والعشاء قرب القطبين.",
                     "reminder_enabled": "إطلاق أحداث تذكير قبل كل صلاة.",
                     "fajr_reminder_minutes": "دقائق قبل الفجر لإطلاق حدث التذكير.",
                     "shuruq_reminder_minutes": "دقائق قبل الشروق لإطلاق حدث التذكير.",

--- a/custom_components/mawaqeet/translations/en.json
+++ b/custom_components/mawaqeet/translations/en.json
@@ -9,19 +9,29 @@
                     "name": "Name",
                     "latitude": "Latitude",
                     "longitude": "Longitude",
-                    "location": "Location",
-                    "calculation_method": "Calculation Method"
+                    "location": "Location"
                 },
                 "data_description": {
                     "name": "Label for this location in Home Assistant.",
-                    "location": "Map position used to calculate prayer times.",
+                    "location": "Map position used to calculate prayer times."
+                }
+            },
+            "calculation": {
+                "title": "Calculation method",
+                "description": "Preview below updates as you change the method. Times are for today at this location.",
+                "data": {
+                    "calculation_method": "Calculation Method"
+                },
+                "data_description": {
                     "calculation_method": "Preset angles and rules for your region."
                 }
             },
             "adjustment": {
                 "title": "Prayer adjustments",
+                "description": "Preview below updates as you change madhab and offsets. Reminder settings do not change the preview. Times are for today at this location.",
                 "data_description": {
                     "madhab": "Affects Asr calculation (Shafi vs Hanafi).",
+                    "high_latitude_rule": "How Fajr and Ishaa are adjusted near the poles.",
                     "reminder_enabled": "Fire reminder events before each prayer.",
                     "fajr_reminder_minutes": "Minutes before Fajr to fire the reminder event.",
                     "shuruq_reminder_minutes": "Minutes before Shuruq to fire the reminder event.",
@@ -55,13 +65,11 @@
                 "title": "Reconfigure Mawaqeet",
                 "data_description": {
                     "name": "Label for this location in Home Assistant.",
-                    "location": "Map position used to calculate prayer times.",
-                    "calculation_method": "Preset angles and rules for your region."
+                    "location": "Map position used to calculate prayer times."
                 },
                 "data": {
                     "name": "Name",
-                    "location": "Location",
-                    "calculation_method": "Calculation Method"
+                    "location": "Location"
                 }
             }
         },
@@ -78,10 +86,22 @@
     "options": {
         "flow_title": "Mawaqeet options",
         "step": {
+            "calculation": {
+                "title": "Calculation method",
+                "description": "Preview below updates as you change the method. Times are for today at this location.",
+                "data": {
+                    "calculation_method": "Calculation Method"
+                },
+                "data_description": {
+                    "calculation_method": "Preset angles and rules for your region."
+                }
+            },
             "adjustment": {
                 "title": "Prayer adjustments",
+                "description": "Preview below updates as you change madhab and offsets. Reminder settings do not change the preview. Times are for today at this location.",
                 "data_description": {
                     "madhab": "Affects Asr calculation (Shafi vs Hanafi).",
+                    "high_latitude_rule": "How Fajr and Ishaa are adjusted near the poles.",
                     "reminder_enabled": "Fire reminder events before each prayer.",
                     "fajr_reminder_minutes": "Minutes before Fajr to fire the reminder event.",
                     "shuruq_reminder_minutes": "Minutes before Shuruq to fire the reminder event.",

--- a/custom_components/mawaqeet/www/mawaqeet-prayer-card.js
+++ b/custom_components/mawaqeet/www/mawaqeet-prayer-card.js
@@ -3,18 +3,18 @@
  * Copyright 2019 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const I = globalThis, J = I.ShadowRoot && (I.ShadyCSS === void 0 || I.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, Q = Symbol(), oe = /* @__PURE__ */ new WeakMap();
-let ye = class {
-  constructor(e, t, i) {
-    if (this._$cssResult$ = !0, i !== Q) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
+const B = globalThis, te = B.ShadowRoot && (B.ShadyCSS === void 0 || B.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, ie = Symbol(), he = /* @__PURE__ */ new WeakMap();
+let Ae = class {
+  constructor(e, t, s) {
+    if (this._$cssResult$ = !0, s !== ie) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
     this.cssText = e, this.t = t;
   }
   get styleSheet() {
     let e = this.o;
     const t = this.t;
-    if (J && e === void 0) {
-      const i = t !== void 0 && t.length === 1;
-      i && (e = oe.get(t)), e === void 0 && ((this.o = e = new CSSStyleSheet()).replaceSync(this.cssText), i && oe.set(t, e));
+    if (te && e === void 0) {
+      const s = t !== void 0 && t.length === 1;
+      s && (e = he.get(t)), e === void 0 && ((this.o = e = new CSSStyleSheet()).replaceSync(this.cssText), s && he.set(t, e));
     }
     return e;
   }
@@ -22,105 +22,105 @@ let ye = class {
     return this.cssText;
   }
 };
-const Oe = (s) => new ye(typeof s == "string" ? s : s + "", void 0, Q), ke = (s, ...e) => {
-  const t = s.length === 1 ? s[0] : e.reduce((i, r, n) => i + ((o) => {
+const Ue = (i) => new Ae(typeof i == "string" ? i : i + "", void 0, ie), qe = (i, ...e) => {
+  const t = i.length === 1 ? i[0] : e.reduce((s, r, n) => s + ((o) => {
     if (o._$cssResult$ === !0) return o.cssText;
     if (typeof o == "number") return o;
     throw Error("Value passed to 'css' function must be a 'css' function result: " + o + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
-  })(r) + s[n + 1], s[0]);
-  return new ye(t, s, Q);
-}, Ue = (s, e) => {
-  if (J) s.adoptedStyleSheets = e.map((t) => t instanceof CSSStyleSheet ? t : t.styleSheet);
+  })(r) + i[n + 1], i[0]);
+  return new Ae(t, i, ie);
+}, ze = (i, e) => {
+  if (te) i.adoptedStyleSheets = e.map((t) => t instanceof CSSStyleSheet ? t : t.styleSheet);
   else for (const t of e) {
-    const i = document.createElement("style"), r = I.litNonce;
-    r !== void 0 && i.setAttribute("nonce", r), i.textContent = t.cssText, s.appendChild(i);
+    const s = document.createElement("style"), r = B.litNonce;
+    r !== void 0 && s.setAttribute("nonce", r), s.textContent = t.cssText, i.appendChild(s);
   }
-}, ae = J ? (s) => s : (s) => s instanceof CSSStyleSheet ? ((e) => {
+}, de = te ? (i) => i : (i) => i instanceof CSSStyleSheet ? ((e) => {
   let t = "";
-  for (const i of e.cssRules) t += i.cssText;
-  return Oe(t);
-})(s) : s;
+  for (const s of e.cssRules) t += s.cssText;
+  return Ue(t);
+})(i) : i;
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const { is: Ne, defineProperty: Me, getOwnPropertyDescriptor: Re, getOwnPropertyNames: ze, getOwnPropertySymbols: De, getPrototypeOf: He } = Object, $ = globalThis, le = $.trustedTypes, qe = le ? le.emptyScript : "", F = $.reactiveElementPolyfillSupport, k = (s, e) => s, L = { toAttribute(s, e) {
+const { is: De, defineProperty: He, getOwnPropertyDescriptor: Re, getOwnPropertyNames: Le, getOwnPropertySymbols: je, getPrototypeOf: Ie } = Object, g = globalThis, ue = g.trustedTypes, Be = ue ? ue.emptyScript : "", J = g.reactiveElementPolyfillSupport, M = (i, e) => i, V = { toAttribute(i, e) {
   switch (e) {
     case Boolean:
-      s = s ? qe : null;
+      i = i ? Be : null;
       break;
     case Object:
     case Array:
-      s = s == null ? s : JSON.stringify(s);
+      i = i == null ? i : JSON.stringify(i);
   }
-  return s;
-}, fromAttribute(s, e) {
-  let t = s;
+  return i;
+}, fromAttribute(i, e) {
+  let t = i;
   switch (e) {
     case Boolean:
-      t = s !== null;
+      t = i !== null;
       break;
     case Number:
-      t = s === null ? null : Number(s);
+      t = i === null ? null : Number(i);
       break;
     case Object:
     case Array:
       try {
-        t = JSON.parse(s);
+        t = JSON.parse(i);
       } catch {
         t = null;
       }
   }
   return t;
-} }, ee = (s, e) => !Ne(s, e), ce = { attribute: !0, type: String, converter: L, reflect: !1, useDefault: !1, hasChanged: ee };
-Symbol.metadata ?? (Symbol.metadata = Symbol("metadata")), $.litPropertyMetadata ?? ($.litPropertyMetadata = /* @__PURE__ */ new WeakMap());
-let x = class extends HTMLElement {
+} }, se = (i, e) => !De(i, e), pe = { attribute: !0, type: String, converter: V, reflect: !1, useDefault: !1, hasChanged: se };
+Symbol.metadata ?? (Symbol.metadata = Symbol("metadata")), g.litPropertyMetadata ?? (g.litPropertyMetadata = /* @__PURE__ */ new WeakMap());
+let A = class extends HTMLElement {
   static addInitializer(e) {
     this._$Ei(), (this.l ?? (this.l = [])).push(e);
   }
   static get observedAttributes() {
     return this.finalize(), this._$Eh && [...this._$Eh.keys()];
   }
-  static createProperty(e, t = ce) {
+  static createProperty(e, t = pe) {
     if (t.state && (t.attribute = !1), this._$Ei(), this.prototype.hasOwnProperty(e) && ((t = Object.create(t)).wrapped = !0), this.elementProperties.set(e, t), !t.noAccessor) {
-      const i = Symbol(), r = this.getPropertyDescriptor(e, i, t);
-      r !== void 0 && Me(this.prototype, e, r);
+      const s = Symbol(), r = this.getPropertyDescriptor(e, s, t);
+      r !== void 0 && He(this.prototype, e, r);
     }
   }
-  static getPropertyDescriptor(e, t, i) {
+  static getPropertyDescriptor(e, t, s) {
     const { get: r, set: n } = Re(this.prototype, e) ?? { get() {
       return this[t];
     }, set(o) {
       this[t] = o;
     } };
     return { get: r, set(o) {
-      const a = r == null ? void 0 : r.call(this);
-      n == null || n.call(this, o), this.requestUpdate(e, a, i);
+      const c = r == null ? void 0 : r.call(this);
+      n == null || n.call(this, o), this.requestUpdate(e, c, s);
     }, configurable: !0, enumerable: !0 };
   }
   static getPropertyOptions(e) {
-    return this.elementProperties.get(e) ?? ce;
+    return this.elementProperties.get(e) ?? pe;
   }
   static _$Ei() {
-    if (this.hasOwnProperty(k("elementProperties"))) return;
-    const e = He(this);
+    if (this.hasOwnProperty(M("elementProperties"))) return;
+    const e = Ie(this);
     e.finalize(), e.l !== void 0 && (this.l = [...e.l]), this.elementProperties = new Map(e.elementProperties);
   }
   static finalize() {
-    if (this.hasOwnProperty(k("finalized"))) return;
-    if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(k("properties"))) {
-      const t = this.properties, i = [...ze(t), ...De(t)];
-      for (const r of i) this.createProperty(r, t[r]);
+    if (this.hasOwnProperty(M("finalized"))) return;
+    if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(M("properties"))) {
+      const t = this.properties, s = [...Le(t), ...je(t)];
+      for (const r of s) this.createProperty(r, t[r]);
     }
     const e = this[Symbol.metadata];
     if (e !== null) {
       const t = litPropertyMetadata.get(e);
-      if (t !== void 0) for (const [i, r] of t) this.elementProperties.set(i, r);
+      if (t !== void 0) for (const [s, r] of t) this.elementProperties.set(s, r);
     }
     this._$Eh = /* @__PURE__ */ new Map();
-    for (const [t, i] of this.elementProperties) {
-      const r = this._$Eu(t, i);
+    for (const [t, s] of this.elementProperties) {
+      const r = this._$Eu(t, s);
       r !== void 0 && this._$Eh.set(r, t);
     }
     this.elementStyles = this.finalizeStyles(this.styles);
@@ -128,14 +128,14 @@ let x = class extends HTMLElement {
   static finalizeStyles(e) {
     const t = [];
     if (Array.isArray(e)) {
-      const i = new Set(e.flat(1 / 0).reverse());
-      for (const r of i) t.unshift(ae(r));
-    } else e !== void 0 && t.push(ae(e));
+      const s = new Set(e.flat(1 / 0).reverse());
+      for (const r of s) t.unshift(de(r));
+    } else e !== void 0 && t.push(de(e));
     return t;
   }
   static _$Eu(e, t) {
-    const i = t.attribute;
-    return i === !1 ? void 0 : typeof i == "string" ? i : typeof e == "string" ? e.toLowerCase() : void 0;
+    const s = t.attribute;
+    return s === !1 ? void 0 : typeof s == "string" ? s : typeof e == "string" ? e.toLowerCase() : void 0;
   }
   constructor() {
     super(), this._$Ep = void 0, this.isUpdatePending = !1, this.hasUpdated = !1, this._$Em = null, this._$Ev();
@@ -154,18 +154,18 @@ let x = class extends HTMLElement {
   }
   _$E_() {
     const e = /* @__PURE__ */ new Map(), t = this.constructor.elementProperties;
-    for (const i of t.keys()) this.hasOwnProperty(i) && (e.set(i, this[i]), delete this[i]);
+    for (const s of t.keys()) this.hasOwnProperty(s) && (e.set(s, this[s]), delete this[s]);
     e.size > 0 && (this._$Ep = e);
   }
   createRenderRoot() {
     const e = this.shadowRoot ?? this.attachShadow(this.constructor.shadowRootOptions);
-    return Ue(e, this.constructor.elementStyles), e;
+    return ze(e, this.constructor.elementStyles), e;
   }
   connectedCallback() {
     var e;
     this.renderRoot ?? (this.renderRoot = this.createRenderRoot()), this.enableUpdating(!0), (e = this._$EO) == null || e.forEach((t) => {
-      var i;
-      return (i = t.hostConnected) == null ? void 0 : i.call(t);
+      var s;
+      return (s = t.hostConnected) == null ? void 0 : s.call(t);
     });
   }
   enableUpdating(e) {
@@ -173,42 +173,42 @@ let x = class extends HTMLElement {
   disconnectedCallback() {
     var e;
     (e = this._$EO) == null || e.forEach((t) => {
-      var i;
-      return (i = t.hostDisconnected) == null ? void 0 : i.call(t);
+      var s;
+      return (s = t.hostDisconnected) == null ? void 0 : s.call(t);
     });
   }
-  attributeChangedCallback(e, t, i) {
-    this._$AK(e, i);
+  attributeChangedCallback(e, t, s) {
+    this._$AK(e, s);
   }
   _$ET(e, t) {
     var n;
-    const i = this.constructor.elementProperties.get(e), r = this.constructor._$Eu(e, i);
-    if (r !== void 0 && i.reflect === !0) {
-      const o = (((n = i.converter) == null ? void 0 : n.toAttribute) !== void 0 ? i.converter : L).toAttribute(t, i.type);
+    const s = this.constructor.elementProperties.get(e), r = this.constructor._$Eu(e, s);
+    if (r !== void 0 && s.reflect === !0) {
+      const o = (((n = s.converter) == null ? void 0 : n.toAttribute) !== void 0 ? s.converter : V).toAttribute(t, s.type);
       this._$Em = e, o == null ? this.removeAttribute(r) : this.setAttribute(r, o), this._$Em = null;
     }
   }
   _$AK(e, t) {
     var n, o;
-    const i = this.constructor, r = i._$Eh.get(e);
+    const s = this.constructor, r = s._$Eh.get(e);
     if (r !== void 0 && this._$Em !== r) {
-      const a = i.getPropertyOptions(r), l = typeof a.converter == "function" ? { fromAttribute: a.converter } : ((n = a.converter) == null ? void 0 : n.fromAttribute) !== void 0 ? a.converter : L;
+      const c = s.getPropertyOptions(r), a = typeof c.converter == "function" ? { fromAttribute: c.converter } : ((n = c.converter) == null ? void 0 : n.fromAttribute) !== void 0 ? c.converter : V;
       this._$Em = r;
-      const c = l.fromAttribute(t, a.type);
-      this[r] = c ?? ((o = this._$Ej) == null ? void 0 : o.get(r)) ?? c, this._$Em = null;
+      const l = a.fromAttribute(t, c.type);
+      this[r] = l ?? ((o = this._$Ej) == null ? void 0 : o.get(r)) ?? l, this._$Em = null;
     }
   }
-  requestUpdate(e, t, i, r = !1, n) {
+  requestUpdate(e, t, s, r = !1, n) {
     var o;
     if (e !== void 0) {
-      const a = this.constructor;
-      if (r === !1 && (n = this[e]), i ?? (i = a.getPropertyOptions(e)), !((i.hasChanged ?? ee)(n, t) || i.useDefault && i.reflect && n === ((o = this._$Ej) == null ? void 0 : o.get(e)) && !this.hasAttribute(a._$Eu(e, i)))) return;
-      this.C(e, t, i);
+      const c = this.constructor;
+      if (r === !1 && (n = this[e]), s ?? (s = c.getPropertyOptions(e)), !((s.hasChanged ?? se)(n, t) || s.useDefault && s.reflect && n === ((o = this._$Ej) == null ? void 0 : o.get(e)) && !this.hasAttribute(c._$Eu(e, s)))) return;
+      this.C(e, t, s);
     }
     this.isUpdatePending === !1 && (this._$ES = this._$EP());
   }
-  C(e, t, { useDefault: i, reflect: r, wrapped: n }, o) {
-    i && !(this._$Ej ?? (this._$Ej = /* @__PURE__ */ new Map())).has(e) && (this._$Ej.set(e, o ?? t ?? this[e]), n !== !0 || o !== void 0) || (this._$AL.has(e) || (this.hasUpdated || i || (t = void 0), this._$AL.set(e, t)), r === !0 && this._$Em !== e && (this._$Eq ?? (this._$Eq = /* @__PURE__ */ new Set())).add(e));
+  C(e, t, { useDefault: s, reflect: r, wrapped: n }, o) {
+    s && !(this._$Ej ?? (this._$Ej = /* @__PURE__ */ new Map())).has(e) && (this._$Ej.set(e, o ?? t ?? this[e]), n !== !0 || o !== void 0) || (this._$AL.has(e) || (this.hasUpdated || s || (t = void 0), this._$AL.set(e, t)), r === !0 && this._$Em !== e && (this._$Eq ?? (this._$Eq = /* @__PURE__ */ new Set())).add(e));
   }
   async _$EP() {
     this.isUpdatePending = !0;
@@ -224,7 +224,7 @@ let x = class extends HTMLElement {
     return this.performUpdate();
   }
   performUpdate() {
-    var i;
+    var s;
     if (!this.isUpdatePending) return;
     if (!this.hasUpdated) {
       if (this.renderRoot ?? (this.renderRoot = this.createRenderRoot()), this._$Ep) {
@@ -233,14 +233,14 @@ let x = class extends HTMLElement {
       }
       const r = this.constructor.elementProperties;
       if (r.size > 0) for (const [n, o] of r) {
-        const { wrapped: a } = o, l = this[n];
-        a !== !0 || this._$AL.has(n) || l === void 0 || this.C(n, void 0, o, l);
+        const { wrapped: c } = o, a = this[n];
+        c !== !0 || this._$AL.has(n) || a === void 0 || this.C(n, void 0, o, a);
       }
     }
     let e = !1;
     const t = this._$AL;
     try {
-      e = this.shouldUpdate(t), e ? (this.willUpdate(t), (i = this._$EO) == null || i.forEach((r) => {
+      e = this.shouldUpdate(t), e ? (this.willUpdate(t), (s = this._$EO) == null || s.forEach((r) => {
         var n;
         return (n = r.hostUpdate) == null ? void 0 : n.call(r);
       }), this.update(t)) : this._$EM();
@@ -253,9 +253,9 @@ let x = class extends HTMLElement {
   }
   _$AE(e) {
     var t;
-    (t = this._$EO) == null || t.forEach((i) => {
+    (t = this._$EO) == null || t.forEach((s) => {
       var r;
-      return (r = i.hostUpdated) == null ? void 0 : r.call(i);
+      return (r = s.hostUpdated) == null ? void 0 : r.call(s);
     }), this.hasUpdated || (this.hasUpdated = !0, this.firstUpdated(e)), this.updated(e);
   }
   _$EM() {
@@ -278,76 +278,76 @@ let x = class extends HTMLElement {
   firstUpdated(e) {
   }
 };
-x.elementStyles = [], x.shadowRootOptions = { mode: "open" }, x[k("elementProperties")] = /* @__PURE__ */ new Map(), x[k("finalized")] = /* @__PURE__ */ new Map(), F == null || F({ ReactiveElement: x }), ($.reactiveElementVersions ?? ($.reactiveElementVersions = [])).push("2.1.2");
+A.elementStyles = [], A.shadowRootOptions = { mode: "open" }, A[M("elementProperties")] = /* @__PURE__ */ new Map(), A[M("finalized")] = /* @__PURE__ */ new Map(), J == null || J({ ReactiveElement: A }), (g.reactiveElementVersions ?? (g.reactiveElementVersions = [])).push("2.1.2");
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const U = globalThis, he = (s) => s, B = U.trustedTypes, de = B ? B.createPolicy("lit-html", { createHTML: (s) => s }) : void 0, we = "$lit$", _ = `lit$${Math.random().toFixed(9).slice(2)}$`, be = "?" + _, je = `<${be}>`, w = document, N = () => w.createComment(""), M = (s) => s === null || typeof s != "object" && typeof s != "function", te = Array.isArray, Ie = (s) => te(s) || typeof (s == null ? void 0 : s[Symbol.iterator]) == "function", X = `[ 	
-\f\r]`, O = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, ue = /-->/g, pe = />/g, v = RegExp(`>|${X}(?:([^\\s"'>=/]+)(${X}*=${X}*(?:[^ 	
-\f\r"'\`<>=]|("|')|))|$)`, "g"), me = /'/g, fe = /"/g, Ae = /^(?:script|style|textarea|title)$/i, Le = (s) => (e, ...t) => ({ _$litType$: s, strings: e, values: t }), p = Le(1), S = Symbol.for("lit-noChange"), u = Symbol.for("lit-nothing"), _e = /* @__PURE__ */ new WeakMap(), g = w.createTreeWalker(w, 129);
-function xe(s, e) {
-  if (!te(s) || !s.hasOwnProperty("raw")) throw Error("invalid template strings array");
-  return de !== void 0 ? de.createHTML(e) : e;
+const N = globalThis, me = (i) => i, K = N.trustedTypes, fe = K ? K.createPolicy("lit-html", { createHTML: (i) => i }) : void 0, Ee = "$lit$", $ = `lit$${Math.random().toFixed(9).slice(2)}$`, Se = "?" + $, Ve = `<${Se}>`, b = document, U = () => b.createComment(""), q = (i) => i === null || typeof i != "object" && typeof i != "function", re = Array.isArray, Ke = (i) => re(i) || typeof (i == null ? void 0 : i[Symbol.iterator]) == "function", X = `[ 	
+\f\r]`, O = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, _e = /-->/g, $e = />/g, y = RegExp(`>|${X}(?:([^\\s"'>=/]+)(${X}*=${X}*(?:[^ 	
+\f\r"'\`<>=]|("|')|))|$)`, "g"), ge = /'/g, ye = /"/g, Ce = /^(?:script|style|textarea|title)$/i, We = (i) => (e, ...t) => ({ _$litType$: i, strings: e, values: t }), m = We(1), S = Symbol.for("lit-noChange"), p = Symbol.for("lit-nothing"), ve = /* @__PURE__ */ new WeakMap(), v = b.createTreeWalker(b, 129);
+function Pe(i, e) {
+  if (!re(i) || !i.hasOwnProperty("raw")) throw Error("invalid template strings array");
+  return fe !== void 0 ? fe.createHTML(e) : e;
 }
-const Be = (s, e) => {
-  const t = s.length - 1, i = [];
+const Fe = (i, e) => {
+  const t = i.length - 1, s = [];
   let r, n = e === 2 ? "<svg>" : e === 3 ? "<math>" : "", o = O;
-  for (let a = 0; a < t; a++) {
-    const l = s[a];
-    let c, d, h = -1, m = 0;
-    for (; m < l.length && (o.lastIndex = m, d = o.exec(l), d !== null); ) m = o.lastIndex, o === O ? d[1] === "!--" ? o = ue : d[1] !== void 0 ? o = pe : d[2] !== void 0 ? (Ae.test(d[2]) && (r = RegExp("</" + d[2], "g")), o = v) : d[3] !== void 0 && (o = v) : o === v ? d[0] === ">" ? (o = r ?? O, h = -1) : d[1] === void 0 ? h = -2 : (h = o.lastIndex - d[2].length, c = d[1], o = d[3] === void 0 ? v : d[3] === '"' ? fe : me) : o === fe || o === me ? o = v : o === ue || o === pe ? o = O : (o = v, r = void 0);
-    const f = o === v && s[a + 1].startsWith("/>") ? " " : "";
-    n += o === O ? l + je : h >= 0 ? (i.push(c), l.slice(0, h) + we + l.slice(h) + _ + f) : l + _ + (h === -2 ? a : f);
+  for (let c = 0; c < t; c++) {
+    const a = i[c];
+    let l, d, h = -1, u = 0;
+    for (; u < a.length && (o.lastIndex = u, d = o.exec(a), d !== null); ) u = o.lastIndex, o === O ? d[1] === "!--" ? o = _e : d[1] !== void 0 ? o = $e : d[2] !== void 0 ? (Ce.test(d[2]) && (r = RegExp("</" + d[2], "g")), o = y) : d[3] !== void 0 && (o = y) : o === y ? d[0] === ">" ? (o = r ?? O, h = -1) : d[1] === void 0 ? h = -2 : (h = o.lastIndex - d[2].length, l = d[1], o = d[3] === void 0 ? y : d[3] === '"' ? ye : ge) : o === ye || o === ge ? o = y : o === _e || o === $e ? o = O : (o = y, r = void 0);
+    const f = o === y && i[c + 1].startsWith("/>") ? " " : "";
+    n += o === O ? a + Ve : h >= 0 ? (s.push(l), a.slice(0, h) + Ee + a.slice(h) + $ + f) : a + $ + (h === -2 ? c : f);
   }
-  return [xe(s, n + (s[t] || "<?>") + (e === 2 ? "</svg>" : e === 3 ? "</math>" : "")), i];
+  return [Pe(i, n + (i[t] || "<?>") + (e === 2 ? "</svg>" : e === 3 ? "</math>" : "")), s];
 };
-class R {
-  constructor({ strings: e, _$litType$: t }, i) {
+class z {
+  constructor({ strings: e, _$litType$: t }, s) {
     let r;
     this.parts = [];
     let n = 0, o = 0;
-    const a = e.length - 1, l = this.parts, [c, d] = Be(e, t);
-    if (this.el = R.createElement(c, i), g.currentNode = this.el.content, t === 2 || t === 3) {
+    const c = e.length - 1, a = this.parts, [l, d] = Fe(e, t);
+    if (this.el = z.createElement(l, s), v.currentNode = this.el.content, t === 2 || t === 3) {
       const h = this.el.content.firstChild;
       h.replaceWith(...h.childNodes);
     }
-    for (; (r = g.nextNode()) !== null && l.length < a; ) {
+    for (; (r = v.nextNode()) !== null && a.length < c; ) {
       if (r.nodeType === 1) {
-        if (r.hasAttributes()) for (const h of r.getAttributeNames()) if (h.endsWith(we)) {
-          const m = d[o++], f = r.getAttribute(h).split(_), A = /([.?@])?(.*)/.exec(m);
-          l.push({ type: 1, index: n, name: A[2], strings: f, ctor: A[1] === "." ? We : A[1] === "?" ? Ke : A[1] === "@" ? Ye : K }), r.removeAttribute(h);
-        } else h.startsWith(_) && (l.push({ type: 6, index: n }), r.removeAttribute(h));
-        if (Ae.test(r.tagName)) {
-          const h = r.textContent.split(_), m = h.length - 1;
-          if (m > 0) {
-            r.textContent = B ? B.emptyScript : "";
-            for (let f = 0; f < m; f++) r.append(h[f], N()), g.nextNode(), l.push({ type: 2, index: ++n });
-            r.append(h[m], N());
+        if (r.hasAttributes()) for (const h of r.getAttributeNames()) if (h.endsWith(Ee)) {
+          const u = d[o++], f = r.getAttribute(h).split($), _ = /([.?@])?(.*)/.exec(u);
+          a.push({ type: 1, index: n, name: _[2], strings: f, ctor: _[1] === "." ? Ge : _[1] === "?" ? Ze : _[1] === "@" ? Je : Y }), r.removeAttribute(h);
+        } else h.startsWith($) && (a.push({ type: 6, index: n }), r.removeAttribute(h));
+        if (Ce.test(r.tagName)) {
+          const h = r.textContent.split($), u = h.length - 1;
+          if (u > 0) {
+            r.textContent = K ? K.emptyScript : "";
+            for (let f = 0; f < u; f++) r.append(h[f], U()), v.nextNode(), a.push({ type: 2, index: ++n });
+            r.append(h[u], U());
           }
         }
-      } else if (r.nodeType === 8) if (r.data === be) l.push({ type: 2, index: n });
+      } else if (r.nodeType === 8) if (r.data === Se) a.push({ type: 2, index: n });
       else {
         let h = -1;
-        for (; (h = r.data.indexOf(_, h + 1)) !== -1; ) l.push({ type: 7, index: n }), h += _.length - 1;
+        for (; (h = r.data.indexOf($, h + 1)) !== -1; ) a.push({ type: 7, index: n }), h += $.length - 1;
       }
       n++;
     }
   }
   static createElement(e, t) {
-    const i = w.createElement("template");
-    return i.innerHTML = e, i;
+    const s = b.createElement("template");
+    return s.innerHTML = e, s;
   }
 }
-function C(s, e, t = s, i) {
-  var o, a;
+function C(i, e, t = i, s) {
+  var o, c;
   if (e === S) return e;
-  let r = i !== void 0 ? (o = t._$Co) == null ? void 0 : o[i] : t._$Cl;
-  const n = M(e) ? void 0 : e._$litDirective$;
-  return (r == null ? void 0 : r.constructor) !== n && ((a = r == null ? void 0 : r._$AO) == null || a.call(r, !1), n === void 0 ? r = void 0 : (r = new n(s), r._$AT(s, t, i)), i !== void 0 ? (t._$Co ?? (t._$Co = []))[i] = r : t._$Cl = r), r !== void 0 && (e = C(s, r._$AS(s, e.values), r, i)), e;
+  let r = s !== void 0 ? (o = t._$Co) == null ? void 0 : o[s] : t._$Cl;
+  const n = q(e) ? void 0 : e._$litDirective$;
+  return (r == null ? void 0 : r.constructor) !== n && ((c = r == null ? void 0 : r._$AO) == null || c.call(r, !1), n === void 0 ? r = void 0 : (r = new n(i), r._$AT(i, t, s)), s !== void 0 ? (t._$Co ?? (t._$Co = []))[s] = r : t._$Cl = r), r !== void 0 && (e = C(i, r._$AS(i, e.values), r, s)), e;
 }
-class Ve {
+class Ye {
   constructor(e, t) {
     this._$AV = [], this._$AN = void 0, this._$AD = e, this._$AM = t;
   }
@@ -358,30 +358,30 @@ class Ve {
     return this._$AM._$AU;
   }
   u(e) {
-    const { el: { content: t }, parts: i } = this._$AD, r = ((e == null ? void 0 : e.creationScope) ?? w).importNode(t, !0);
-    g.currentNode = r;
-    let n = g.nextNode(), o = 0, a = 0, l = i[0];
-    for (; l !== void 0; ) {
-      if (o === l.index) {
-        let c;
-        l.type === 2 ? c = new z(n, n.nextSibling, this, e) : l.type === 1 ? c = new l.ctor(n, l.name, l.strings, this, e) : l.type === 6 && (c = new Fe(n, this, e)), this._$AV.push(c), l = i[++a];
+    const { el: { content: t }, parts: s } = this._$AD, r = ((e == null ? void 0 : e.creationScope) ?? b).importNode(t, !0);
+    v.currentNode = r;
+    let n = v.nextNode(), o = 0, c = 0, a = s[0];
+    for (; a !== void 0; ) {
+      if (o === a.index) {
+        let l;
+        a.type === 2 ? l = new D(n, n.nextSibling, this, e) : a.type === 1 ? l = new a.ctor(n, a.name, a.strings, this, e) : a.type === 6 && (l = new Xe(n, this, e)), this._$AV.push(l), a = s[++c];
       }
-      o !== (l == null ? void 0 : l.index) && (n = g.nextNode(), o++);
+      o !== (a == null ? void 0 : a.index) && (n = v.nextNode(), o++);
     }
-    return g.currentNode = w, r;
+    return v.currentNode = b, r;
   }
   p(e) {
     let t = 0;
-    for (const i of this._$AV) i !== void 0 && (i.strings !== void 0 ? (i._$AI(e, i, t), t += i.strings.length - 2) : i._$AI(e[t])), t++;
+    for (const s of this._$AV) s !== void 0 && (s.strings !== void 0 ? (s._$AI(e, s, t), t += s.strings.length - 2) : s._$AI(e[t])), t++;
   }
 }
-class z {
+class D {
   get _$AU() {
     var e;
     return ((e = this._$AM) == null ? void 0 : e._$AU) ?? this._$Cv;
   }
-  constructor(e, t, i, r) {
-    this.type = 2, this._$AH = u, this._$AN = void 0, this._$AA = e, this._$AB = t, this._$AM = i, this.options = r, this._$Cv = (r == null ? void 0 : r.isConnected) ?? !0;
+  constructor(e, t, s, r) {
+    this.type = 2, this._$AH = p, this._$AN = void 0, this._$AA = e, this._$AB = t, this._$AM = s, this.options = r, this._$Cv = (r == null ? void 0 : r.isConnected) ?? !0;
   }
   get parentNode() {
     let e = this._$AA.parentNode;
@@ -395,7 +395,7 @@ class z {
     return this._$AB;
   }
   _$AI(e, t = this) {
-    e = C(this, e, t), M(e) ? e === u || e == null || e === "" ? (this._$AH !== u && this._$AR(), this._$AH = u) : e !== this._$AH && e !== S && this._(e) : e._$litType$ !== void 0 ? this.$(e) : e.nodeType !== void 0 ? this.T(e) : Ie(e) ? this.k(e) : this._(e);
+    e = C(this, e, t), q(e) ? e === p || e == null || e === "" ? (this._$AH !== p && this._$AR(), this._$AH = p) : e !== this._$AH && e !== S && this._(e) : e._$litType$ !== void 0 ? this.$(e) : e.nodeType !== void 0 ? this.T(e) : Ke(e) ? this.k(e) : this._(e);
   }
   O(e) {
     return this._$AA.parentNode.insertBefore(e, this._$AB);
@@ -404,33 +404,33 @@ class z {
     this._$AH !== e && (this._$AR(), this._$AH = this.O(e));
   }
   _(e) {
-    this._$AH !== u && M(this._$AH) ? this._$AA.nextSibling.data = e : this.T(w.createTextNode(e)), this._$AH = e;
+    this._$AH !== p && q(this._$AH) ? this._$AA.nextSibling.data = e : this.T(b.createTextNode(e)), this._$AH = e;
   }
   $(e) {
     var n;
-    const { values: t, _$litType$: i } = e, r = typeof i == "number" ? this._$AC(e) : (i.el === void 0 && (i.el = R.createElement(xe(i.h, i.h[0]), this.options)), i);
+    const { values: t, _$litType$: s } = e, r = typeof s == "number" ? this._$AC(e) : (s.el === void 0 && (s.el = z.createElement(Pe(s.h, s.h[0]), this.options)), s);
     if (((n = this._$AH) == null ? void 0 : n._$AD) === r) this._$AH.p(t);
     else {
-      const o = new Ve(r, this), a = o.u(this.options);
-      o.p(t), this.T(a), this._$AH = o;
+      const o = new Ye(r, this), c = o.u(this.options);
+      o.p(t), this.T(c), this._$AH = o;
     }
   }
   _$AC(e) {
-    let t = _e.get(e.strings);
-    return t === void 0 && _e.set(e.strings, t = new R(e)), t;
+    let t = ve.get(e.strings);
+    return t === void 0 && ve.set(e.strings, t = new z(e)), t;
   }
   k(e) {
-    te(this._$AH) || (this._$AH = [], this._$AR());
+    re(this._$AH) || (this._$AH = [], this._$AR());
     const t = this._$AH;
-    let i, r = 0;
-    for (const n of e) r === t.length ? t.push(i = new z(this.O(N()), this.O(N()), this, this.options)) : i = t[r], i._$AI(n), r++;
-    r < t.length && (this._$AR(i && i._$AB.nextSibling, r), t.length = r);
+    let s, r = 0;
+    for (const n of e) r === t.length ? t.push(s = new D(this.O(U()), this.O(U()), this, this.options)) : s = t[r], s._$AI(n), r++;
+    r < t.length && (this._$AR(s && s._$AB.nextSibling, r), t.length = r);
   }
   _$AR(e = this._$AA.nextSibling, t) {
-    var i;
-    for ((i = this._$AP) == null ? void 0 : i.call(this, !1, !0, t); e !== this._$AB; ) {
-      const r = he(e).nextSibling;
-      he(e).remove(), e = r;
+    var s;
+    for ((s = this._$AP) == null ? void 0 : s.call(this, !1, !0, t); e !== this._$AB; ) {
+      const r = me(e).nextSibling;
+      me(e).remove(), e = r;
     }
   }
   setConnected(e) {
@@ -438,64 +438,64 @@ class z {
     this._$AM === void 0 && (this._$Cv = e, (t = this._$AP) == null || t.call(this, e));
   }
 }
-class K {
+class Y {
   get tagName() {
     return this.element.tagName;
   }
   get _$AU() {
     return this._$AM._$AU;
   }
-  constructor(e, t, i, r, n) {
-    this.type = 1, this._$AH = u, this._$AN = void 0, this.element = e, this.name = t, this._$AM = r, this.options = n, i.length > 2 || i[0] !== "" || i[1] !== "" ? (this._$AH = Array(i.length - 1).fill(new String()), this.strings = i) : this._$AH = u;
+  constructor(e, t, s, r, n) {
+    this.type = 1, this._$AH = p, this._$AN = void 0, this.element = e, this.name = t, this._$AM = r, this.options = n, s.length > 2 || s[0] !== "" || s[1] !== "" ? (this._$AH = Array(s.length - 1).fill(new String()), this.strings = s) : this._$AH = p;
   }
-  _$AI(e, t = this, i, r) {
+  _$AI(e, t = this, s, r) {
     const n = this.strings;
     let o = !1;
-    if (n === void 0) e = C(this, e, t, 0), o = !M(e) || e !== this._$AH && e !== S, o && (this._$AH = e);
+    if (n === void 0) e = C(this, e, t, 0), o = !q(e) || e !== this._$AH && e !== S, o && (this._$AH = e);
     else {
-      const a = e;
-      let l, c;
-      for (e = n[0], l = 0; l < n.length - 1; l++) c = C(this, a[i + l], t, l), c === S && (c = this._$AH[l]), o || (o = !M(c) || c !== this._$AH[l]), c === u ? e = u : e !== u && (e += (c ?? "") + n[l + 1]), this._$AH[l] = c;
+      const c = e;
+      let a, l;
+      for (e = n[0], a = 0; a < n.length - 1; a++) l = C(this, c[s + a], t, a), l === S && (l = this._$AH[a]), o || (o = !q(l) || l !== this._$AH[a]), l === p ? e = p : e !== p && (e += (l ?? "") + n[a + 1]), this._$AH[a] = l;
     }
     o && !r && this.j(e);
   }
   j(e) {
-    e === u ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, e ?? "");
+    e === p ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, e ?? "");
   }
 }
-class We extends K {
+class Ge extends Y {
   constructor() {
     super(...arguments), this.type = 3;
   }
   j(e) {
-    this.element[this.name] = e === u ? void 0 : e;
+    this.element[this.name] = e === p ? void 0 : e;
   }
 }
-class Ke extends K {
+class Ze extends Y {
   constructor() {
     super(...arguments), this.type = 4;
   }
   j(e) {
-    this.element.toggleAttribute(this.name, !!e && e !== u);
+    this.element.toggleAttribute(this.name, !!e && e !== p);
   }
 }
-class Ye extends K {
-  constructor(e, t, i, r, n) {
-    super(e, t, i, r, n), this.type = 5;
+class Je extends Y {
+  constructor(e, t, s, r, n) {
+    super(e, t, s, r, n), this.type = 5;
   }
   _$AI(e, t = this) {
-    if ((e = C(this, e, t, 0) ?? u) === S) return;
-    const i = this._$AH, r = e === u && i !== u || e.capture !== i.capture || e.once !== i.once || e.passive !== i.passive, n = e !== u && (i === u || r);
-    r && this.element.removeEventListener(this.name, this, i), n && this.element.addEventListener(this.name, this, e), this._$AH = e;
+    if ((e = C(this, e, t, 0) ?? p) === S) return;
+    const s = this._$AH, r = e === p && s !== p || e.capture !== s.capture || e.once !== s.once || e.passive !== s.passive, n = e !== p && (s === p || r);
+    r && this.element.removeEventListener(this.name, this, s), n && this.element.addEventListener(this.name, this, e), this._$AH = e;
   }
   handleEvent(e) {
     var t;
     typeof this._$AH == "function" ? this._$AH.call(((t = this.options) == null ? void 0 : t.host) ?? this.element, e) : this._$AH.handleEvent(e);
   }
 }
-class Fe {
-  constructor(e, t, i) {
-    this.element = e, this.type = 6, this._$AN = void 0, this._$AM = t, this.options = i;
+class Xe {
+  constructor(e, t, s) {
+    this.element = e, this.type = 6, this._$AN = void 0, this._$AM = t, this.options = s;
   }
   get _$AU() {
     return this._$AM._$AU;
@@ -504,24 +504,24 @@ class Fe {
     C(this, e);
   }
 }
-const Z = U.litHtmlPolyfillSupport;
-Z == null || Z(R, z), (U.litHtmlVersions ?? (U.litHtmlVersions = [])).push("3.3.3");
-const Xe = (s, e, t) => {
-  const i = (t == null ? void 0 : t.renderBefore) ?? e;
-  let r = i._$litPart$;
+const Q = N.litHtmlPolyfillSupport;
+Q == null || Q(z, D), (N.litHtmlVersions ?? (N.litHtmlVersions = [])).push("3.3.3");
+const Qe = (i, e, t) => {
+  const s = (t == null ? void 0 : t.renderBefore) ?? e;
+  let r = s._$litPart$;
   if (r === void 0) {
     const n = (t == null ? void 0 : t.renderBefore) ?? null;
-    i._$litPart$ = r = new z(e.insertBefore(N(), n), n, void 0, t ?? {});
+    s._$litPart$ = r = new D(e.insertBefore(U(), n), n, void 0, t ?? {});
   }
-  return r._$AI(s), r;
+  return r._$AI(i), r;
 };
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const y = globalThis;
-class E extends x {
+const w = globalThis;
+class E extends A {
   constructor() {
     super(...arguments), this.renderOptions = { host: this }, this._$Do = void 0;
   }
@@ -532,7 +532,7 @@ class E extends x {
   }
   update(e) {
     const t = this.render();
-    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(e), this._$Do = Xe(t, this.renderRoot, this.renderOptions);
+    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(e), this._$Do = Qe(t, this.renderRoot, this.renderOptions);
   }
   connectedCallback() {
     var e;
@@ -546,71 +546,62 @@ class E extends x {
     return S;
   }
 }
-var ge;
-E._$litElement$ = !0, E.finalized = !0, (ge = y.litElementHydrateSupport) == null || ge.call(y, { LitElement: E });
-const G = y.litElementPolyfillSupport;
-G == null || G({ LitElement: E });
-(y.litElementVersions ?? (y.litElementVersions = [])).push("4.2.2");
+var xe;
+E._$litElement$ = !0, E.finalized = !0, (xe = w.litElementHydrateSupport) == null || xe.call(w, { LitElement: E });
+const ee = w.litElementPolyfillSupport;
+ee == null || ee({ LitElement: E });
+(w.litElementVersions ?? (w.litElementVersions = [])).push("4.2.2");
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const Ee = (s) => (e, t) => {
+const ke = (i) => (e, t) => {
   t !== void 0 ? t.addInitializer(() => {
-    customElements.define(s, e);
-  }) : customElements.define(s, e);
+    customElements.define(i, e);
+  }) : customElements.define(i, e);
 };
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const Ze = { attribute: !0, type: String, converter: L, reflect: !1, hasChanged: ee }, Ge = (s = Ze, e, t) => {
-  const { kind: i, metadata: r } = t;
+const et = { attribute: !0, type: String, converter: V, reflect: !1, hasChanged: se }, tt = (i = et, e, t) => {
+  const { kind: s, metadata: r } = t;
   let n = globalThis.litPropertyMetadata.get(r);
-  if (n === void 0 && globalThis.litPropertyMetadata.set(r, n = /* @__PURE__ */ new Map()), i === "setter" && ((s = Object.create(s)).wrapped = !0), n.set(t.name, s), i === "accessor") {
+  if (n === void 0 && globalThis.litPropertyMetadata.set(r, n = /* @__PURE__ */ new Map()), s === "setter" && ((i = Object.create(i)).wrapped = !0), n.set(t.name, i), s === "accessor") {
     const { name: o } = t;
-    return { set(a) {
-      const l = e.get.call(this);
-      e.set.call(this, a), this.requestUpdate(o, l, s, !0, a);
-    }, init(a) {
-      return a !== void 0 && this.C(o, void 0, s, a), a;
+    return { set(c) {
+      const a = e.get.call(this);
+      e.set.call(this, c), this.requestUpdate(o, a, i, !0, c);
+    }, init(c) {
+      return c !== void 0 && this.C(o, void 0, i, c), c;
     } };
   }
-  if (i === "setter") {
+  if (s === "setter") {
     const { name: o } = t;
-    return function(a) {
-      const l = this[o];
-      e.call(this, a), this.requestUpdate(o, l, s, !0, a);
+    return function(c) {
+      const a = this[o];
+      e.call(this, c), this.requestUpdate(o, a, i, !0, c);
     };
   }
-  throw Error("Unsupported decorator location: " + i);
+  throw Error("Unsupported decorator location: " + s);
 };
-function ie(s) {
-  return (e, t) => typeof t == "object" ? Ge(s, e, t) : ((i, r, n) => {
+function ne(i) {
+  return (e, t) => typeof t == "object" ? tt(i, e, t) : ((s, r, n) => {
     const o = r.hasOwnProperty(n);
-    return r.constructor.createProperty(n, i), o ? Object.getOwnPropertyDescriptor(r, n) : void 0;
-  })(s, e, t);
+    return r.constructor.createProperty(n, s), o ? Object.getOwnPropertyDescriptor(r, n) : void 0;
+  })(i, e, t);
 }
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-function se(s) {
-  return ie({ ...s, state: !0, attribute: !1 });
+function oe(i) {
+  return ne({ ...i, state: !0, attribute: !1 });
 }
-const Je = [
-  "fajr",
-  "dhuhr",
-  "asr",
-  "maghrib",
-  "ishaa"
-], Qe = "shuruq", et = /* @__PURE__ */ new Set([
-  "midnight",
-  "last_third"
-]), tt = /* @__PURE__ */ new Set([
+const it = "shuruq", st = "midnight", rt = "last_third", nt = /* @__PURE__ */ new Set([
   "calculation_method",
   "madhab",
   "high_latitude_rule",
@@ -626,118 +617,140 @@ const Je = [
   "maghrib_offset",
   "ishaa_offset"
 ]);
-function Se(s) {
-  return s ? ["fajr", Qe, "dhuhr", "asr", "maghrib", "ishaa"] : [...Je];
+function ae(i = {}) {
+  const e = ["fajr"];
+  return i.showShuruq && e.push(it), e.push("dhuhr", "asr", "maghrib", "ishaa"), i.showMidnight && e.push(st), i.showLastThird && e.push(rt), e;
 }
-function it(s, e) {
-  return et.has(s) || tt.has(s) ? !1 : Se(e).includes(s);
+function ot(i = {}) {
+  return 5 + (i.showShuruq ? 1 : 0);
 }
-function $e(s, e) {
-  const i = Se(e).indexOf(s);
-  return i === -1 ? 999 : i;
+function at(i, e = {}) {
+  return nt.has(i) ? !1 : ae(e).includes(i);
 }
-const st = "mawaqeet", rt = "mdi:mosque";
-function nt(s) {
+function we(i, e = {}) {
+  const s = ae(e).indexOf(i);
+  return s === -1 ? 999 : s;
+}
+const lt = "mawaqeet", ct = "mdi:mosque", ht = {
+  fajr: "mdi:weather-sunset-up",
+  shuruq: "mdi:weather-sunny",
+  dhuhr: "mdi:white-balance-sunny",
+  asr: "mdi:weather-partly-cloudy",
+  maghrib: "mdi:weather-sunset",
+  ishaa: "mdi:weather-night",
+  midnight: "mdi:clock-time-twelve",
+  last_third: "mdi:clock-outline"
+};
+function dt(i, e, t) {
+  const s = t == null ? void 0 : t[i];
+  return s || e || ht[i] || ct;
+}
+function ut(i) {
   var t;
-  return s.translation_key ? s.translation_key : ((t = s.entity_id.split(".").pop()) == null ? void 0 : t.split("_").pop()) ?? null;
+  return i.translation_key ? i.translation_key : ((t = i.entity_id.split(".").pop()) == null ? void 0 : t.split("_").pop()) ?? null;
 }
-function ot(s, e, t) {
-  if (!e || !s.entities)
+function pt(i, e, t = {}, s) {
+  if (!e || !i.entities)
     return [];
-  const i = [];
-  for (const n of Object.values(s.entities)) {
-    if (n.platform !== st || n.device_id !== e || !n.entity_id.startsWith("sensor."))
+  const r = ae(t), n = [];
+  for (const a of Object.values(i.entities)) {
+    if (a.platform !== lt || a.device_id !== e || !a.entity_id.startsWith("sensor."))
       continue;
-    const o = nt(n);
-    if (!o || !it(o, t))
+    const l = ut(a);
+    if (!l || !at(l, t))
       continue;
-    const a = s.states[n.entity_id];
-    if (!a || a.state === "unavailable" || a.state === "unknown")
+    const d = i.states[a.entity_id];
+    if (!d || d.state === "unavailable" || d.state === "unknown")
       continue;
-    const l = a.attributes.device_class;
-    if (l && l !== "timestamp")
+    const h = d.attributes.device_class;
+    if (h && h !== "timestamp")
       continue;
-    const c = new Date(a.state);
-    Number.isNaN(c.getTime()) || i.push({
-      entity_id: n.entity_id,
-      prayer_key: o,
-      label: lt(s, n, a),
-      icon: a.attributes.icon || rt,
-      at: c,
-      state: a
+    const u = new Date(d.state);
+    Number.isNaN(u.getTime()) || n.push({
+      entity_id: a.entity_id,
+      prayer_key: l,
+      label: mt(i, a, d),
+      icon: dt(
+        l,
+        d.attributes.icon,
+        s
+      ),
+      at: u,
+      state: d
     });
   }
-  i.sort(
-    (n, o) => $e(n.prayer_key, t) - $e(o.prayer_key, t)
+  n.sort(
+    (a, l) => we(a.prayer_key, t) - we(l.prayer_key, t)
   );
-  const r = t ? 6 : at;
-  return i.length < r ? [] : i;
+  const o = ot(t);
+  return n.filter(
+    (a) => r.filter((l) => l !== "midnight" && l !== "last_third").includes(a.prayer_key)
+  ).length < o ? [] : n;
 }
-const at = 5;
-function Y(s, e = /* @__PURE__ */ new Date()) {
-  if (s.length === 0)
+function H(i, e = /* @__PURE__ */ new Date()) {
+  if (i.length === 0)
     return null;
-  const t = s.filter((n) => n.at.getTime() > e.getTime());
+  const t = i.filter((n) => n.at.getTime() > e.getTime());
   if (t.length > 0)
     return {
       prayer: t[0],
       following: t[1] ?? null,
       isTomorrow: !1
     };
-  const i = s.find((n) => n.prayer_key === "fajr") ?? s[0], r = s.find((n) => n.prayer_key !== i.prayer_key) ?? null;
+  const s = i.find((n) => n.prayer_key === "fajr") ?? i[0], r = i.find((n) => n.prayer_key !== s.prayer_key) ?? null;
   return {
-    prayer: i,
+    prayer: s,
     following: r,
     isTomorrow: !0
   };
 }
-function lt(s, e, t) {
-  var i;
+function mt(i, e, t) {
+  var s;
   if (e.translation_key) {
-    const r = `component.mawaqeet.entity.sensor.${e.translation_key}.name`, n = (i = s.localize) == null ? void 0 : i.call(s, r);
+    const r = `component.mawaqeet.entity.sensor.${e.translation_key}.name`, n = (s = i.localize) == null ? void 0 : s.call(i, r);
     if (n && n !== r)
       return n;
   }
   return t.attributes.friendly_name || e.entity_id;
 }
-function P(s, e, t) {
+function P(i, e, t) {
   var r, n;
-  const i = t === "12" || t === "system" && ((r = e.locale) == null ? void 0 : r.time_format) === "12";
+  const s = t === "12" || t === "system" && ((r = e.locale) == null ? void 0 : r.time_format) === "12";
   return new Intl.DateTimeFormat(((n = e.locale) == null ? void 0 : n.language) || void 0, {
     hour: "numeric",
     minute: "2-digit",
-    hour12: i
-  }).format(s);
+    hour12: s
+  }).format(i);
 }
-function re(s, e = /* @__PURE__ */ new Date(), t = !1) {
-  const i = s.getTime() - e.getTime();
-  if (t && i < 0) {
-    const r = new Date(s);
-    return r.setDate(r.getDate() + 1), ve(r.getTime() - e.getTime());
+function le(i, e = /* @__PURE__ */ new Date(), t = !1) {
+  const s = i.getTime() - e.getTime();
+  if (t && s < 0) {
+    const r = new Date(i);
+    return r.setDate(r.getDate() + 1), be(r.getTime() - e.getTime());
   }
-  return ve(i);
+  return be(s);
 }
-function ve(s) {
-  const e = Math.abs(s), t = Math.round(e / 6e4);
+function be(i) {
+  const e = Math.abs(i), t = Math.round(e / 6e4);
   if (t < 1)
-    return s >= 0 ? "now" : "just now";
+    return i >= 0 ? "now" : "just now";
   if (t < 60)
-    return s >= 0 ? `in ${t}m` : `${t}m ago`;
-  const i = Math.floor(t / 60), r = t % 60;
-  if (i < 24) {
-    const o = r > 0 ? `${i}h ${r}m` : `${i}h`;
-    return s >= 0 ? `in ${o}` : `${o} ago`;
+    return i >= 0 ? `in ${t}m` : `${t}m ago`;
+  const s = Math.floor(t / 60), r = t % 60;
+  if (s < 24) {
+    const o = r > 0 ? `${s}h ${r}m` : `${s}h`;
+    return i >= 0 ? `in ${o}` : `${o} ago`;
   }
-  const n = Math.floor(i / 24);
-  return s >= 0 ? `in ${n}d` : `${n}d ago`;
+  const n = Math.floor(s / 24);
+  return i >= 0 ? `in ${n}d` : `${n}d ago`;
 }
-function ct(s, e) {
-  var i;
-  const t = (i = s.devices) == null ? void 0 : i[e];
+function ft(i, e) {
+  var s;
+  const t = (s = i.devices) == null ? void 0 : s[e];
   return t ? t.name_by_user || t.name || e : "";
 }
-function ht(s) {
-  switch (s) {
+function _t(i) {
+  switch (i) {
     case "horizontal":
     case "combined":
       return {
@@ -750,7 +763,7 @@ function ht(s) {
       return {
         columns: 12,
         rows: 3,
-        min_rows: 2,
+        min_rows: 3,
         max_rows: 4
       };
     case "vertical":
@@ -771,182 +784,215 @@ function ht(s) {
       };
   }
 }
-function D(s, e) {
+function R(i, e) {
   return e.time_format ?? "system";
 }
-function H(s, e) {
+function L(i, e) {
   if (!e.show_device_name || !e.device)
-    return u;
-  const t = ct(s, e.device);
-  return t ? p`<div class="header">${t}</div>` : u;
+    return p;
+  const t = ft(i, e.device);
+  return t ? m`<div class="header">${t}</div>` : p;
 }
-function V(s) {
-  return p`<div class="error">${s}</div>`;
+function W(i) {
+  return m`<div class="error">${i}</div>`;
 }
-function q(s) {
-  return p`<ha-icon .icon=${s}></ha-icon>`;
+function j(i) {
+  return m`<span class="icon-slot" aria-hidden="true"
+    ><ha-icon .icon=${i}></ha-icon
+  ></span>`;
 }
-function j(s, e) {
+function Te(i, e) {
   return (t) => {
-    t.stopPropagation(), e(s);
+    t.stopPropagation(), e(i);
   };
 }
-function Ce(s, e, t, i, r) {
-  const n = Y(t, i);
-  if (!n)
-    return V("No prayer times available.");
-  const { prayer: o, following: a, isTomorrow: l } = n, c = D(s, e), d = re(o.at, i, l), h = P(o.at, s, c), m = a && p`Following: ${a.label} at ${P(a.at, s, c)}`;
-  return p`
-    ${H(s, e)}
+function Oe(i, e) {
+  return (t) => {
+    (t.key === "Enter" || t.key === " ") && (t.preventDefault(), t.stopPropagation(), e(i));
+  };
+}
+function G(i, e, t, s, r) {
+  return m`
     <div
-      class="next-hero"
-      @click=${j(o.entity_id, r)}
+      class=${t}
+      @click=${Te(i, e)}
+      @keydown=${Oe(i, e)}
       role="button"
       tabindex="0"
+      aria-label=${r ?? p}
     >
-      ${q(o.icon)}
-      <div class="prayer-name">${o.label}</div>
-      <div class="countdown">${d} · ${h}</div>
-      ${l ? p`<div class="following">Tomorrow</div>` : u}
-      ${m ? p`<div class="following">${m}</div>` : u}
+      ${s}
     </div>
   `;
 }
-function dt(s, e, t, i, r) {
-  const n = Y(t, i), o = n == null ? void 0 : n.prayer.entity_id, a = D(s, e), l = e.show_relative !== !1;
-  return p`
-    ${H(s, e)}
-    ${t.map((c) => {
-    const d = c.entity_id === o, h = e.show_passed_style !== !1 && c.at.getTime() < i.getTime(), m = ["row", d ? "next" : "", h ? "passed strike" : ""].filter(Boolean).join(" ");
-    return p`
-        <div
-          class=${m}
-          @click=${j(c.entity_id, r)}
-          role="button"
-          tabindex="0"
-        >
-          ${q(c.icon)}
-          <span class="name">${c.label}</span>
+function Me(i, e, t, s, r) {
+  const n = H(t, s);
+  if (!n)
+    return W("No prayer times available.");
+  const { prayer: o, following: c, isTomorrow: a } = n, l = R(i, e), d = le(o.at, s, a), h = P(o.at, i, l), u = c && m`Following: ${c.label} at ${P(c.at, i, l)}`, f = `Next prayer: ${o.label} ${d} at ${h}`;
+  return m`
+    ${L(i, e)}
+    ${G(
+    o.entity_id,
+    r,
+    "next-hero",
+    m`
+        ${j(o.icon)}
+        <div class="prayer-name">${o.label}</div>
+        <div class="countdown">${d}</div>
+        <div class="at-time">${h}</div>
+        ${a ? m`<div class="tomorrow-badge">Tomorrow</div>` : p}
+        ${u ? m`<div class="following">${u}</div>` : p}
+      `,
+    f
+  )}
+  `;
+}
+function $t(i, e, t, s, r) {
+  const n = H(t, s), o = n == null ? void 0 : n.prayer.entity_id, c = R(i, e), a = e.show_relative !== !1;
+  return m`
+    ${L(i, e)}
+    ${t.map((l) => {
+    const d = l.entity_id === o, h = e.show_passed_style !== !1 && l.at.getTime() < s.getTime(), u = ["row", d ? "next" : "", h ? "passed" : ""].filter(Boolean).join(" "), f = P(l.at, i, c);
+    return G(
+      l.entity_id,
+      r,
+      u,
+      m`
+          ${j(l.icon)}
+          <span class="name">${l.label}</span>
           <span class="times">
-            <div>${P(c.at, s, a)}</div>
-            ${l ? p`<div class="relative">
-                  ${re(c.at, i)}
-                </div>` : u}
+            <div>${f}</div>
+            ${a ? m`<div class="relative">
+                  ${le(l.at, s)}
+                </div>` : p}
           </span>
-        </div>
-      `;
+        `,
+      `${l.label} ${f}`
+    );
   })}
   `;
 }
-function Pe(s, e, t, i, r) {
-  const n = Y(t, i), o = n == null ? void 0 : n.prayer.entity_id, a = D(s, e), l = e.show_relative === !0;
-  return p`
-    ${H(s, e)}
+function Ne(i, e, t, s, r) {
+  const n = H(t, s), o = n == null ? void 0 : n.prayer.entity_id, c = R(i, e), a = e.show_relative === !0;
+  return m`
+    ${L(i, e)}
     <div class="horizontal">
-      ${t.map((c) => {
-    const d = c.entity_id === o, h = e.show_passed_style !== !1 && c.at.getTime() < i.getTime(), m = ["chip", d ? "next" : "", h ? "passed" : ""].filter(Boolean).join(" ");
-    return p`
-          <div
-            class=${m}
-            @click=${j(c.entity_id, r)}
-            role="button"
-            tabindex="0"
-          >
-            ${q(c.icon)}
-            <div>${c.label}</div>
-            <div class="chip-time">${P(c.at, s, a)}</div>
-            ${l ? p`<div class="chip-relative">
-                  ${re(c.at, i)}
-                </div>` : u}
-          </div>
-        `;
+      ${t.map((l) => {
+    const d = l.entity_id === o, h = e.show_passed_style !== !1 && l.at.getTime() < s.getTime(), u = ["chip", d ? "next" : "", h ? "passed" : ""].filter(Boolean).join(" "), f = P(l.at, i, c);
+    return G(
+      l.entity_id,
+      r,
+      u,
+      m`
+            ${j(l.icon)}
+            <div>${l.label}</div>
+            <div class="chip-time">${f}</div>
+            ${a ? m`<div class="chip-relative">
+                  ${le(l.at, s)}
+                </div>` : p}
+          `,
+      `${l.label} ${f}`
+    );
   })}
     </div>
   `;
 }
-function ut(s, e, t, i, r) {
-  return p`
-    ${Ce(s, { ...e, show_device_name: !1 }, t, i, r)}
+function gt(i, e, t, s, r) {
+  return m`
+    ${Me(i, { ...e, show_device_name: !1 }, t, s, r)}
     <hr class="divider" />
-    ${Pe(
-    s,
+    ${Ne(
+    i,
     { ...e, show_device_name: !1, show_relative: !1 },
     t,
-    i,
+    s,
     r
   )}
   `;
 }
-function pt(s, e, t, i, r) {
-  const n = Y(t, i), o = n == null ? void 0 : n.prayer.entity_id, a = t.filter((h) => h.at.getTime() > i.getTime()), l = t.filter((h) => h.at.getTime() <= i.getTime()), c = D(s, e), d = (h, m) => p`
+function yt(i, e, t, s, r) {
+  const n = H(t, s), o = n == null ? void 0 : n.prayer.entity_id, c = t.filter((h) => h.at.getTime() > s.getTime()), a = t.filter((h) => h.at.getTime() <= s.getTime()), l = R(i, e), d = (h, u) => m`
     <div class="section-title">${h}</div>
-    ${m.map((f) => {
-    const A = f.entity_id === o, ne = l.includes(f), Te = ["row", A ? "next" : "", ne ? "passed" : ""].filter(Boolean).join(" ");
-    return p`
-        <div
-          class=${Te}
-          @click=${j(f.entity_id, r)}
-          role="button"
-          tabindex="0"
-        >
-          ${ne ? p`<span class="agenda-check">✓</span>` : u}
-          ${q(f.icon)}
+    ${u.map((f) => {
+    const _ = f.entity_id === o, I = a.includes(f), Z = ["row", _ ? "next" : "", I ? "passed" : ""].filter(Boolean).join(" "), T = P(f.at, i, l);
+    return G(
+      f.entity_id,
+      r,
+      Z,
+      m`
+          <span class="agenda-status" aria-hidden="true">
+            ${I ? m`<ha-icon .icon=${"mdi:check"}></ha-icon>` : p}
+          </span>
+          ${j(f.icon)}
           <span class="name">${f.label}</span>
-          <span class="times">${P(f.at, s, c)}</span>
-        </div>
-      `;
+          <span class="times">${T}</span>
+        `,
+      `${f.label} ${T}`
+    );
   })}
   `;
-  return p`
-    ${H(s, e)}
-    ${l.length ? d("Earlier today", l) : u}
-    ${a.length ? d("Upcoming", a) : d("Upcoming", t)}
+  return m`
+    ${L(i, e)}
+    ${a.length ? d("Earlier today", a) : p}
+    ${c.length ? d("Upcoming", c) : m`<div class="section-title">Upcoming</div>
+          <div class="agenda-empty">All prayers complete for today</div>`}
   `;
 }
-function mt(s, e, t, i, r) {
+function vt(i, e, t, s, r) {
   if (t.length < 2)
-    return V("Not enough prayer times for timeline.");
-  const n = t[0].at.getTime(), a = t[t.length - 1].at.getTime() - n || 1, l = Math.min(100, Math.max(0, (i.getTime() - n) / a * 100)), c = D(s, e);
-  return p`
-    ${H(s, e)}
+    return W("Not enough prayer times for timeline.");
+  const n = t[0].at.getTime(), c = t[t.length - 1].at.getTime() - n || 1, a = Math.min(
+    100,
+    Math.max(0, (s.getTime() - n) / c * 100)
+  ), l = R(i, e), d = H(t, s), h = d == null ? void 0 : d.prayer.entity_id;
+  return m`
+    ${L(i, e)}
     <div class="timeline">
       <div class="timeline-track"></div>
-      <div class="timeline-now" style="left: ${l}%"></div>
-      ${t.map((d) => {
-    const h = (d.at.getTime() - n) / a * 100;
-    return p`
+      <div class="timeline-now" style="left: ${a}%"></div>
+      ${t.map((u) => {
+    const f = (u.at.getTime() - n) / c * 100, _ = u.entity_id === h, I = e.show_passed_style !== !1 && u.at.getTime() < s.getTime(), Z = [
+      "timeline-marker",
+      _ ? "next" : "",
+      I ? "passed" : ""
+    ].filter(Boolean).join(" "), T = P(u.at, i, l), ce = `${u.label} ${T}`;
+    return m`
           <div
-            class="timeline-marker"
-            style="left: ${h}%"
-            @click=${j(d.entity_id, r)}
+            class=${Z}
+            style="left: ${f}%"
+            @click=${Te(u.entity_id, r)}
+            @keydown=${Oe(u.entity_id, r)}
             role="button"
             tabindex="0"
+            aria-label=${ce}
+            title=${ce}
           >
-            ${q(d.icon)}
-            <div>${d.label}</div>
-            <div>${P(d.at, s, c)}</div>
+            ${j(u.icon)}
+            <div>${u.label}</div>
+            <div>${T}</div>
           </div>
         `;
   })}
     </div>
   `;
 }
-function ft(s, e, t, i, r) {
+function wt(i, e, t, s, r) {
   switch (e.layout ?? "next") {
     case "horizontal":
-      return Pe(s, e, t, i, r);
+      return Ne(i, e, t, s, r);
     case "vertical":
-      return dt(s, e, t, i, r);
+      return $t(i, e, t, s, r);
     case "combined":
-      return ut(s, e, t, i, r);
+      return gt(i, e, t, s, r);
     case "timeline":
-      return mt(s, e, t, i, r);
+      return vt(i, e, t, s, r);
     case "agenda":
-      return pt(s, e, t, i, r);
+      return yt(i, e, t, s, r);
   }
-  return Ce(s, e, t, i, r);
+  return Me(i, e, t, s, r);
 }
-const _t = ke`
+const bt = qe`
   :host {
     display: block;
     height: 100%;
@@ -963,7 +1009,7 @@ const _t = ke`
   .header {
     font-size: 0.85em;
     opacity: 0.7;
-    margin-bottom: 12px;
+    margin-bottom: 8px;
   }
 
   .error {
@@ -971,11 +1017,18 @@ const _t = ke`
     padding: 8px 0;
   }
 
+  .icon-slot {
+    width: 24px;
+    flex-shrink: 0;
+    display: grid;
+    place-items: center;
+  }
+
   .row {
     display: flex;
     align-items: center;
-    gap: 12px;
-    padding: 8px 4px;
+    gap: 10px;
+    padding: 6px 4px;
     border-radius: 8px;
     cursor: pointer;
   }
@@ -987,20 +1040,26 @@ const _t = ke`
   .row.next {
     font-weight: 600;
     background: rgba(var(--rgb-primary-color, 3, 169, 244), 0.12);
+    box-shadow: inset 3px 0 0 var(--primary-color);
   }
 
-  .row.passed {
-    opacity: 0.45;
+  .row.passed,
+  .chip.passed,
+  .timeline-marker.passed {
+    opacity: 0.6;
+    color: var(--secondary-text-color);
   }
 
-  .row.passed.strike {
-    text-decoration: line-through;
+  .row.passed ha-icon,
+  .chip.passed ha-icon,
+  .timeline-marker.passed ha-icon {
+    color: var(--secondary-text-color);
   }
 
-  .row ha-icon {
+  .row ha-icon,
+  .chip ha-icon {
     --mdc-icon-size: 22px;
     color: var(--primary-color);
-    flex-shrink: 0;
   }
 
   .row .name {
@@ -1021,10 +1080,16 @@ const _t = ke`
   .next-hero {
     text-align: center;
     padding: 8px 0 16px;
+    cursor: pointer;
+  }
+
+  .next-hero .icon-slot {
+    width: auto;
+    margin: 0 auto;
   }
 
   .next-hero ha-icon {
-    --mdc-icon-size: 48px;
+    --mdc-icon-size: 40px;
     color: var(--primary-color);
   }
 
@@ -1035,8 +1100,26 @@ const _t = ke`
   }
 
   .next-hero .countdown {
-    font-size: 1.25em;
+    font-size: 1.35em;
     color: var(--primary-color);
+    font-weight: 600;
+  }
+
+  .next-hero .at-time {
+    font-size: 0.95em;
+    opacity: 0.75;
+    margin-top: 2px;
+  }
+
+  .next-hero .tomorrow-badge {
+    display: inline-block;
+    margin-top: 8px;
+    padding: 2px 10px;
+    border-radius: 999px;
+    font-size: 0.75em;
+    font-weight: 600;
+    color: var(--primary-color);
+    background: rgba(var(--rgb-primary-color, 3, 169, 244), 0.12);
   }
 
   .next-hero .following {
@@ -1057,11 +1140,12 @@ const _t = ke`
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 8px 10px;
+    padding: 8px 8px;
     border-radius: 8px;
     min-width: 4.5em;
     border: 1px solid transparent;
     cursor: pointer;
+    gap: 2px;
   }
 
   .chip.next {
@@ -1070,18 +1154,9 @@ const _t = ke`
     font-weight: 600;
   }
 
-  .chip.passed {
-    opacity: 0.45;
-  }
-
-  .chip ha-icon {
-    --mdc-icon-size: 20px;
-    color: var(--primary-color);
-  }
-
   .chip .chip-time {
     font-size: 0.95em;
-    margin-top: 4px;
+    margin-top: 2px;
   }
 
   .chip .chip-relative {
@@ -1098,14 +1173,34 @@ const _t = ke`
   .section-title {
     font-size: 0.75em;
     text-transform: uppercase;
+    letter-spacing: 0.04em;
     opacity: 0.6;
-    margin: 8px 0 4px;
+    margin: 12px 0 6px;
+  }
+
+  .agenda-empty {
+    font-size: 0.9em;
+    opacity: 0.65;
+    padding: 4px 0 8px;
+  }
+
+  .agenda-status {
+    width: 20px;
+    flex-shrink: 0;
+    display: grid;
+    place-items: center;
+    color: var(--secondary-text-color);
+  }
+
+  .agenda-status ha-icon {
+    --mdc-icon-size: 18px;
+    color: var(--secondary-text-color);
   }
 
   .timeline {
     position: relative;
-    height: 48px;
-    margin: 24px 8px 32px;
+    height: 80px;
+    margin: 28px 12px 36px;
   }
 
   .timeline-track {
@@ -1124,51 +1219,62 @@ const _t = ke`
     top: 0;
     transform: translateX(-50%);
     text-align: center;
-    font-size: 0.65em;
+    font-size: 0.72em;
     white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .timeline-marker .icon-slot {
+    width: auto;
+    margin: 0 auto;
   }
 
   .timeline-marker ha-icon {
-    --mdc-icon-size: 16px;
+    --mdc-icon-size: 18px;
     color: var(--primary-color);
+  }
+
+  .timeline-marker.next {
+    font-weight: 600;
+  }
+
+  .timeline-marker.next ha-icon {
+    --mdc-icon-size: 20px;
   }
 
   .timeline-now {
     position: absolute;
     top: -4px;
     width: 2px;
-    height: 56px;
+    height: 88px;
     background: var(--accent-color, var(--primary-color));
     transform: translateX(-50%);
     z-index: 1;
   }
-
-  .agenda-check {
-    opacity: 0.5;
-    margin-inline-end: 4px;
-  }
 `;
-var $t = Object.defineProperty, vt = Object.getOwnPropertyDescriptor, b = (s, e, t, i) => {
-  for (var r = i > 1 ? void 0 : i ? vt(e, t) : e, n = s.length - 1, o; n >= 0; n--)
-    (o = s[n]) && (r = (i ? o(e, t, r) : o(r)) || r);
-  return i && r && $t(e, t, r), r;
+var xt = Object.defineProperty, At = Object.getOwnPropertyDescriptor, x = (i, e, t, s) => {
+  for (var r = s > 1 ? void 0 : s ? At(e, t) : e, n = i.length - 1, o; n >= 0; n--)
+    (o = i[n]) && (r = (s ? o(e, t, r) : o(r)) || r);
+  return s && r && xt(e, t, r), r;
 };
-let T = class extends E {
+let k = class extends E {
   constructor() {
     super(...arguments), this._now = /* @__PURE__ */ new Date();
   }
-  setConfig(s) {
-    if (!s.device)
+  setConfig(i) {
+    if (!i.device)
       throw new Error("Set a Mawaqeet device for this card.");
     this._config = {
       type: "custom:mawaqeet-prayer-card",
       layout: "next",
       show_shuruq: !1,
+      show_midnight: !1,
+      show_last_third: !1,
       show_passed_style: !0,
       time_format: "system",
       show_relative: !0,
       show_device_name: !1,
-      ...s
+      ...i
     };
   }
   getCardSize() {
@@ -1188,8 +1294,8 @@ let T = class extends E {
   }
   getGridOptions() {
     var e;
-    const s = ((e = this._config) == null ? void 0 : e.layout) ?? "next";
-    return ht(s);
+    const i = ((e = this._config) == null ? void 0 : e.layout) ?? "next";
+    return _t(i);
   }
   static async getConfigElement() {
     return document.createElement("mawaqeet-prayer-card-editor");
@@ -1198,7 +1304,9 @@ let T = class extends E {
     return {
       type: "custom:mawaqeet-prayer-card",
       layout: "next",
-      show_shuruq: !1
+      show_shuruq: !1,
+      show_midnight: !1,
+      show_last_third: !1
     };
   }
   connectedCallback() {
@@ -1209,134 +1317,177 @@ let T = class extends E {
   disconnectedCallback() {
     super.disconnectedCallback(), this._clockInterval !== void 0 && window.clearInterval(this._clockInterval);
   }
-  willUpdate(s) {
-    s.has("hass") && (this._now = /* @__PURE__ */ new Date());
+  willUpdate(i) {
+    i.has("hass") && (this._now = /* @__PURE__ */ new Date());
   }
   render() {
     if (!this.hass || !this._config)
-      return p`<ha-card><div class="error">Loading…</div></ha-card>`;
-    const s = this._config.show_shuruq === !0, e = ot(
+      return m`<ha-card><div class="error">Loading…</div></ha-card>`;
+    const i = {
+      showShuruq: this._config.show_shuruq === !0,
+      showMidnight: this._config.show_midnight === !0,
+      showLastThird: this._config.show_last_third === !0
+    }, e = pt(
       this.hass,
       this._config.device,
-      s
+      i,
+      this._config.icons
     );
     let t;
-    return this._config.device ? e.length === 0 ? t = V(
+    return this._config.device ? e.length === 0 ? t = W(
       "No prayer times found for this device. Check that Mawaqeet is loaded."
-    ) : t = ft(
+    ) : t = wt(
       this.hass,
       this._config,
       e,
       this._now,
-      (i) => this._moreInfo(i)
-    ) : t = V("Select a Mawaqeet location device in card settings."), p`<ha-card>${t}</ha-card>`;
+      (s) => this._moreInfo(s)
+    ) : t = W("Select a Mawaqeet location device in card settings."), m`<ha-card>${t}</ha-card>`;
   }
-  _moreInfo(s) {
+  _moreInfo(i) {
     const e = new CustomEvent("hass-more-info", {
       bubbles: !0,
       composed: !0,
-      detail: { entityId: s }
+      detail: { entityId: i }
     });
     this.dispatchEvent(e);
   }
 };
-T.styles = _t;
-b([
-  ie({ attribute: !1 })
-], T.prototype, "hass", 2);
-b([
-  se()
-], T.prototype, "_config", 2);
-b([
-  se()
-], T.prototype, "_now", 2);
-T = b([
-  Ee("mawaqeet-prayer-card")
-], T);
-const gt = [
-  {
-    name: "device",
-    required: !0,
-    selector: {
-      device: { filter: { integration: "mawaqeet" } }
-    }
-  },
-  {
-    name: "layout",
-    selector: {
-      select: {
-        options: [
-          { value: "next", label: "Next prayer" },
-          { value: "horizontal", label: "Horizontal timetable" },
-          { value: "vertical", label: "Vertical timetable" },
-          { value: "combined", label: "Combined (next + horizontal)" },
-          { value: "timeline", label: "Day timeline" },
-          { value: "agenda", label: "Agenda" }
-        ]
+k.styles = bt;
+x([
+  ne({ attribute: !1 })
+], k.prototype, "hass", 2);
+x([
+  oe()
+], k.prototype, "_config", 2);
+x([
+  oe()
+], k.prototype, "_now", 2);
+k = x([
+  ke("mawaqeet-prayer-card")
+], k);
+function Et(i) {
+  const e = [
+    { name: "fajr", selector: { icon: {} } }
+  ];
+  return i.show_shuruq && e.push({ name: "shuruq", selector: { icon: {} } }), e.push(
+    { name: "dhuhr", selector: { icon: {} } },
+    { name: "asr", selector: { icon: {} } },
+    { name: "maghrib", selector: { icon: {} } },
+    { name: "ishaa", selector: { icon: {} } }
+  ), i.show_midnight && e.push({ name: "midnight", selector: { icon: {} } }), i.show_last_third && e.push({ name: "last_third", selector: { icon: {} } }), [
+    {
+      name: "device",
+      required: !0,
+      selector: {
+        device: { filter: { integration: "mawaqeet" } }
       }
-    }
-  },
-  { name: "show_shuruq", selector: { boolean: {} } },
-  { name: "show_passed_style", selector: { boolean: {} } },
-  {
-    name: "time_format",
-    selector: {
-      select: {
-        options: [
-          { value: "system", label: "System" },
-          { value: "24", label: "24-hour" },
-          { value: "12", label: "12-hour" }
-        ]
+    },
+    {
+      name: "layout",
+      selector: {
+        select: {
+          options: [
+            { value: "next", label: "Next prayer" },
+            { value: "horizontal", label: "Horizontal timetable" },
+            { value: "vertical", label: "Vertical timetable" },
+            { value: "combined", label: "Combined (next + horizontal)" },
+            { value: "timeline", label: "Day timeline" },
+            { value: "agenda", label: "Agenda" }
+          ]
+        }
       }
+    },
+    { name: "show_shuruq", selector: { boolean: {} } },
+    { name: "show_midnight", selector: { boolean: {} } },
+    { name: "show_last_third", selector: { boolean: {} } },
+    { name: "show_passed_style", selector: { boolean: {} } },
+    {
+      name: "time_format",
+      selector: {
+        select: {
+          options: [
+            { value: "system", label: "System" },
+            { value: "24", label: "24-hour" },
+            { value: "12", label: "12-hour" }
+          ]
+        }
+      }
+    },
+    { name: "show_relative", selector: { boolean: {} } },
+    { name: "show_device_name", selector: { boolean: {} } },
+    {
+      name: "icons",
+      type: "expandable",
+      title: "Custom prayer icons",
+      schema: e,
+      expanded: !1
     }
-  },
-  { name: "show_relative", selector: { boolean: {} } },
-  { name: "show_device_name", selector: { boolean: {} } }
-];
-let W = class extends E {
-  setConfig(s) {
-    this._config = s;
+  ];
+}
+function St(i) {
+  if (!i)
+    return;
+  const e = {};
+  for (const [t, s] of Object.entries(i))
+    typeof s == "string" && s.trim() && (e[t] = s.trim());
+  return Object.keys(e).length ? e : void 0;
+}
+let F = class extends E {
+  setConfig(i) {
+    this._config = i;
   }
   render() {
-    return !this.hass || !this._config ? p`` : p`
+    return !this.hass || !this._config ? m`` : m`
       <ha-form
         .hass=${this.hass}
         .data=${this._config}
-        .schema=${gt}
-        .computeLabel=${(s) => yt[s.name] ?? s.name}
+        .schema=${Et(this._config)}
+        .computeLabel=${(i) => Ct[i.name] ?? i.name}
         @value-changed=${this._changed}
       ></ha-form>
     `;
   }
-  _changed(s) {
-    s.stopPropagation();
-    const e = s.detail.value;
-    this._config = e;
-    const t = new CustomEvent("config-changed", {
-      detail: { config: e },
+  _changed(i) {
+    i.stopPropagation();
+    const e = i.detail.value, t = St(e.icons), s = { ...e };
+    t ? s.icons = t : delete s.icons, this._config = s;
+    const r = new CustomEvent("config-changed", {
+      detail: { config: s },
       bubbles: !0,
       composed: !0
     });
-    this.dispatchEvent(t);
+    this.dispatchEvent(r);
   }
 };
-b([
-  ie({ attribute: !1 })
-], W.prototype, "hass", 2);
-b([
-  se()
-], W.prototype, "_config", 2);
-W = b([
-  Ee("mawaqeet-prayer-card-editor")
-], W);
-const yt = {
+x([
+  ne({ attribute: !1 })
+], F.prototype, "hass", 2);
+x([
+  oe()
+], F.prototype, "_config", 2);
+F = x([
+  ke("mawaqeet-prayer-card-editor")
+], F);
+const Ct = {
   device: "Mawaqeet location",
   layout: "Layout",
   show_shuruq: "Show Shuruq (sunrise)",
+  show_midnight: "Show Midnight",
+  show_last_third: "Show Last Third",
   show_passed_style: "Dim passed prayers",
   time_format: "Time format",
   show_relative: "Show relative times",
-  show_device_name: "Show location name"
+  show_device_name: "Show location name",
+  icons: "Custom prayer icons",
+  fajr: "Fajr",
+  shuruq: "Shuruq",
+  dhuhr: "Dhuhr",
+  asr: "Asr",
+  maghrib: "Maghrib",
+  ishaa: "Ishaa",
+  midnight: "Midnight",
+  last_third: "Last Third"
 };
 typeof window < "u" && (window.customCards = window.customCards || [], window.customCards.push({
   type: "mawaqeet-prayer-card",
@@ -1345,6 +1496,6 @@ typeof window < "u" && (window.customCards = window.customCards || [], window.cu
   preview: !0
 }));
 export {
-  T as MawaqeetPrayerCard,
-  W as MawaqeetPrayerCardEditor
+  k as MawaqeetPrayerCard,
+  F as MawaqeetPrayerCardEditor
 };

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -7,6 +7,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.mawaqeet.calculation import (
     async_compute_prayer_times,
     compute_prayer_times,
+    compute_prayer_times_from_options,
 )
 from custom_components.mawaqeet.const import CALCULATION_METHOD, DOMAIN, MADHAB
 from custom_components.mawaqeet.enum import PrayerTime, PrayerTimeOption
@@ -36,3 +37,67 @@ async def test_compute_prayer_times(hass: HomeAssistant) -> None:
         async_data["prayer_times"][PrayerTime.FAJR]
         == sync_data["prayer_times"][PrayerTime.FAJR]
     )
+
+
+async def test_compute_prayer_times_from_options_matches_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Test param-based compute matches ConfigEntry-based compute."""
+    location = {CONF_LATITUDE: 51.5074, CONF_LONGITUDE: -0.1278}
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_NAME: "Home", CONF_LOCATION: location},
+        options={CALCULATION_METHOD: "mwl", MADHAB: "shafi"},
+    )
+    entry.add_to_hass(hass)
+
+    from_entry = compute_prayer_times(entry)
+    from_options = compute_prayer_times_from_options(
+        location,
+        {CALCULATION_METHOD: "mwl", MADHAB: "shafi"},
+    )
+
+    assert from_options["prayer_times"] == from_entry["prayer_times"]
+    assert (
+        from_options["prayer_times_config"][PrayerTimeOption.CALCULATION_METHOD]
+        == "mwl"
+    )
+
+
+def test_offset_changes_prayer_times() -> None:
+    """Test prayer offsets change computed times."""
+    location = {CONF_LATITUDE: 51.5074, CONF_LONGITUDE: -0.1278}
+    base = compute_prayer_times_from_options(
+        location, {CALCULATION_METHOD: "mwl", MADHAB: "shafi"}
+    )
+    shifted = compute_prayer_times_from_options(
+        location,
+        {CALCULATION_METHOD: "mwl", MADHAB: "shafi", "fajr": 10},
+    )
+    assert (
+        shifted["prayer_times"][PrayerTime.FAJR]
+        != base["prayer_times"][PrayerTime.FAJR]
+    )
+
+
+def test_preset_ignores_leftover_custom_interval() -> None:
+    """Test non-custom compute ignores stale ishaa_interval in options."""
+    location = {CONF_LATITUDE: 51.5074, CONF_LONGITUDE: -0.1278}
+    clean = compute_prayer_times_from_options(
+        location, {CALCULATION_METHOD: "mwl", MADHAB: "shafi"}
+    )
+    polluted = compute_prayer_times_from_options(
+        location,
+        {
+            CALCULATION_METHOD: "mwl",
+            MADHAB: "shafi",
+            "ishaa_interval": 90,
+            "fajr_angle": 12.0,
+            "ishaa_angle": 12.0,
+        },
+    )
+    assert (
+        polluted["prayer_times"][PrayerTime.ISHAA]
+        == clean["prayer_times"][PrayerTime.ISHAA]
+    )
+    assert polluted["prayer_times_config"][PrayerTimeOption.ISHAA_INTERVAL] == 0

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7,15 +7,18 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.mawaqeet.calculation import compute_prayer_times
+from custom_components.mawaqeet.config_flow import _build_adjustment_schema
 from custom_components.mawaqeet.const import (
     CALCULATION_METHOD,
     DOMAIN,
     FAJR_ANGLE,
+    HIGH_LATITUDE_RULE,
     ISHAA_ANGLE,
     ISHAA_INTERVAL,
     MADHAB,
 )
-from custom_components.mawaqeet.enum import CalculationMethod
+from custom_components.mawaqeet.enum import CalculationMethod, PrayerTime
 
 
 def _location_unique_id(latitude: float, longitude: float) -> str:
@@ -24,7 +27,7 @@ def _location_unique_id(latitude: float, longitude: float) -> str:
 
 
 async def test_user_flow(hass: HomeAssistant) -> None:
-    """Test user step leads to adjustment."""
+    """Test user step leads to calculation then adjustment."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -36,8 +39,14 @@ async def test_user_flow(hass: HomeAssistant) -> None:
         {
             CONF_NAME: "Home",
             CONF_LOCATION: {CONF_LATITUDE: 51.5, CONF_LONGITUDE: -0.12},
-            CALCULATION_METHOD: "mwl",
         },
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "calculation"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CALCULATION_METHOD: "mwl"},
     )
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "adjustment"
@@ -48,6 +57,8 @@ async def test_user_flow(hass: HomeAssistant) -> None:
     )
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "Home"
+    assert CALCULATION_METHOD not in result["data"]
+    assert result["options"][CALCULATION_METHOD] == "mwl"
 
 
 async def test_duplicate_location(hass: HomeAssistant) -> None:
@@ -61,8 +72,8 @@ async def test_duplicate_location(hass: HomeAssistant) -> None:
         data={
             CONF_NAME: "Existing",
             CONF_LOCATION: location,
-            CALCULATION_METHOD: "mwl",
         },
+        options={CALCULATION_METHOD: "mwl"},
     ).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -73,7 +84,6 @@ async def test_duplicate_location(hass: HomeAssistant) -> None:
         {
             CONF_NAME: "Other",
             CONF_LOCATION: location,
-            CALCULATION_METHOD: "mwl",
         },
     )
     assert result["type"] == FlowResultType.ABORT
@@ -81,7 +91,7 @@ async def test_duplicate_location(hass: HomeAssistant) -> None:
 
 
 async def test_reconfigure_flow(hass: HomeAssistant) -> None:
-    """Test reconfigure updates entry data."""
+    """Test reconfigure updates entry data without touching calculation method."""
     location = {CONF_LATITUDE: 51.5, CONF_LONGITUDE: -0.12}
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -92,9 +102,8 @@ async def test_reconfigure_flow(hass: HomeAssistant) -> None:
         data={
             CONF_NAME: "Home",
             CONF_LOCATION: location,
-            CALCULATION_METHOD: "mwl",
         },
-        options={MADHAB: "shafi"},
+        options={CALCULATION_METHOD: "mwl", MADHAB: "shafi"},
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -109,14 +118,14 @@ async def test_reconfigure_flow(hass: HomeAssistant) -> None:
         {
             CONF_NAME: "NYC",
             CONF_LOCATION: new_location,
-            CALCULATION_METHOD: "isna",
         },
     )
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
     assert entry.data[CONF_NAME] == "NYC"
     assert entry.data[CONF_LOCATION] == new_location
-    assert entry.data[CALCULATION_METHOD] == "isna"
+    assert CALCULATION_METHOD not in entry.data
+    assert entry.options[CALCULATION_METHOD] == "mwl"
     assert entry.unique_id == _location_unique_id(
         new_location[CONF_LATITUDE], new_location[CONF_LONGITUDE]
     )
@@ -136,8 +145,13 @@ async def test_custom_calculation_adjustment(hass: HomeAssistant) -> None:
         {
             CONF_NAME: "Custom",
             CONF_LOCATION: {CONF_LATITUDE: 51.5, CONF_LONGITUDE: -0.12},
-            CALCULATION_METHOD: str(CalculationMethod.CUSTOM),
         },
+    )
+    assert result["step_id"] == "calculation"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CALCULATION_METHOD: str(CalculationMethod.CUSTOM)},
     )
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "adjustment"
@@ -154,11 +168,13 @@ async def test_custom_calculation_adjustment(hass: HomeAssistant) -> None:
     )
     assert result["type"] == FlowResultType.CREATE_ENTRY
     entry = hass.config_entries.async_entries(DOMAIN)[-1]
+    assert entry.options[CALCULATION_METHOD] == str(CalculationMethod.CUSTOM)
     assert entry.options[FAJR_ANGLE] == 18.0
+    assert CALCULATION_METHOD not in entry.data
 
 
-async def test_options_flow_reload(hass: HomeAssistant) -> None:
-    """Test saving options reloads the config entry."""
+async def test_options_flow_change_method(hass: HomeAssistant) -> None:
+    """Test options flow can change calculation method then adjustments."""
     location = {CONF_LATITUDE: 51.5074, CONF_LONGITUDE: -0.1278}
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -169,9 +185,8 @@ async def test_options_flow_reload(hass: HomeAssistant) -> None:
         data={
             CONF_NAME: "Home",
             CONF_LOCATION: location,
-            CALCULATION_METHOD: "mwl",
         },
-        options={MADHAB: "shafi"},
+        options={CALCULATION_METHOD: "mwl", MADHAB: "shafi"},
     )
     entry.add_to_hass(hass)
 
@@ -179,6 +194,13 @@ async def test_options_flow_reload(hass: HomeAssistant) -> None:
     assert entry.state == ConfigEntryState.LOADED
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "calculation"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CALCULATION_METHOD: "isna"},
+    )
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "adjustment"
 
@@ -190,4 +212,145 @@ async def test_options_flow_reload(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert entry.state == ConfigEntryState.LOADED
+    assert entry.options[CALCULATION_METHOD] == "isna"
     assert entry.options[MADHAB] == "hanafi"
+    entry.runtime_data.coordinator.clear_event_sub()
+
+
+async def test_options_flow_custom_shows_angles(hass: HomeAssistant) -> None:
+    """Test switching to custom method in options shows angle fields."""
+    location = {CONF_LATITUDE: 51.5074, CONF_LONGITUDE: -0.1278}
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Home",
+        unique_id=_location_unique_id(
+            location[CONF_LATITUDE], location[CONF_LONGITUDE]
+        ),
+        data={
+            CONF_NAME: "Home",
+            CONF_LOCATION: location,
+        },
+        options={CALCULATION_METHOD: "mwl", MADHAB: "shafi"},
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CALCULATION_METHOD: str(CalculationMethod.CUSTOM)},
+    )
+    assert result["step_id"] == "adjustment"
+    assert FAJR_ANGLE in result["data_schema"].schema
+    entry.runtime_data.coordinator.clear_event_sub()
+
+
+async def test_migrate_calculation_method_from_data(hass: HomeAssistant) -> None:
+    """Test setup migrates calculation method from data into options."""
+    location = {CONF_LATITUDE: 51.5, CONF_LONGITUDE: -0.12}
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Home",
+        unique_id=_location_unique_id(
+            location[CONF_LATITUDE], location[CONF_LONGITUDE]
+        ),
+        data={
+            CONF_NAME: "Home",
+            CONF_LOCATION: location,
+            CALCULATION_METHOD: "isna",
+        },
+        options={MADHAB: "shafi"},
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    assert entry.state == ConfigEntryState.LOADED
+    assert CALCULATION_METHOD not in entry.data
+    assert entry.options[CALCULATION_METHOD] == "isna"
+    entry.runtime_data.coordinator.clear_event_sub()
+
+
+async def test_migrate_strips_method_when_in_both_data_and_options(
+    hass: HomeAssistant,
+) -> None:
+    """Test dual data+options method keeps options and strips data."""
+    location = {CONF_LATITUDE: 51.5, CONF_LONGITUDE: -0.12}
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Home",
+        unique_id=_location_unique_id(
+            location[CONF_LATITUDE], location[CONF_LONGITUDE]
+        ),
+        data={
+            CONF_NAME: "Home",
+            CONF_LOCATION: location,
+            CALCULATION_METHOD: "mwl",
+        },
+        options={CALCULATION_METHOD: "isna", MADHAB: "shafi"},
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    assert CALCULATION_METHOD not in entry.data
+    assert entry.options[CALCULATION_METHOD] == "isna"
+    entry.runtime_data.coordinator.clear_event_sub()
+
+
+async def test_options_custom_to_mwl_strips_angles(hass: HomeAssistant) -> None:
+    """Test custom→MWL drops angles and matches clean MWL Ishaa."""
+    location = {CONF_LATITUDE: 51.5074, CONF_LONGITUDE: -0.1278}
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Home",
+        unique_id=_location_unique_id(
+            location[CONF_LATITUDE], location[CONF_LONGITUDE]
+        ),
+        data={CONF_NAME: "Home", CONF_LOCATION: location},
+        options={
+            CALCULATION_METHOD: str(CalculationMethod.CUSTOM),
+            MADHAB: "shafi",
+            FAJR_ANGLE: 12.0,
+            ISHAA_ANGLE: 12.0,
+            ISHAA_INTERVAL: 90,
+        },
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CALCULATION_METHOD: "mwl"},
+    )
+    assert result["step_id"] == "adjustment"
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {MADHAB: "shafi"},
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    await hass.async_block_till_done()
+
+    assert entry.options[CALCULATION_METHOD] == "mwl"
+    assert FAJR_ANGLE not in entry.options
+    assert ISHAA_ANGLE not in entry.options
+    assert ISHAA_INTERVAL not in entry.options
+
+    clean_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_NAME: "Clean", CONF_LOCATION: location},
+        options={CALCULATION_METHOD: "mwl", MADHAB: "shafi"},
+    )
+    asserted = compute_prayer_times(entry)
+    clean = compute_prayer_times(clean_entry)
+    assert (
+        asserted["prayer_times"][PrayerTime.ISHAA]
+        == clean["prayer_times"][PrayerTime.ISHAA]
+    )
+    entry.runtime_data.coordinator.clear_event_sub()
+
+
+def test_adjustment_schema_includes_high_latitude_for_preset() -> None:
+    """Test high latitude rule is available for non-custom methods."""
+    schema = _build_adjustment_schema("mwl")
+    assert HIGH_LATITUDE_RULE in schema.schema
+    assert FAJR_ANGLE not in schema.schema

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,7 +1,10 @@
 """Test coordinator."""
 
+from datetime import UTC, datetime
+from unittest.mock import PropertyMock, patch
+
 from homeassistant.const import CONF_LATITUDE, CONF_LOCATION, CONF_LONGITUDE, CONF_NAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.mawaqeet.calculation import async_compute_prayer_times
@@ -10,6 +13,8 @@ from custom_components.mawaqeet.const import (
     DEFAULT_REMINDER_MINUTES,
     DOMAIN,
     MADHAB,
+    MAWAQEET_EVENT,
+    PRAYER_TIME_TRIGGER,
     REMINDER_ENABLED,
     REMINDER_MINUTES,
 )
@@ -126,3 +131,46 @@ async def test_legacy_reminder_minutes_fallback(hass: HomeAssistant) -> None:
 
     coordinator = MawaqeetDataUpdateCoordinator(hass, entry)
     assert coordinator._get_reminder_minutes(PrayerTime.FAJR) == 20
+
+
+async def test_scheduled_fire_resolves_device_id_at_fire_time(
+    hass: HomeAssistant,
+) -> None:
+    """Test scheduled callbacks read device_id when firing, not when scheduling."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_NAME: "Home",
+            CONF_LOCATION: {CONF_LATITUDE: 51.5074, CONF_LONGITUDE: -0.1278},
+        },
+        options={CALCULATION_METHOD: "mwl", MADHAB: "shafi"},
+    )
+    entry.add_to_hass(hass)
+
+    coordinator = MawaqeetDataUpdateCoordinator(hass, entry)
+    entry.runtime_data = MawaqeetRuntimeData(coordinator=coordinator)
+
+    fired: list[dict] = []
+
+    def capture(event: Event) -> None:
+        fired.append(event.data)
+
+    hass.bus.async_listen(MAWAQEET_EVENT, capture)
+
+    with patch.object(
+        type(coordinator),
+        "device_id",
+        new_callable=PropertyMock,
+        return_value="device-abc",
+    ) as mock_device_id:
+        fire_cb = coordinator._async_fire_prayer_event(
+            PRAYER_TIME_TRIGGER, str(PrayerTime.FAJR)
+        )
+        mock_device_id.assert_not_called()
+        fire_cb(datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC))
+        await hass.async_block_till_done()
+        mock_device_id.assert_called()
+
+    assert fired
+    assert fired[0]["device_id"] == "device-abc"
+    assert fired[0]["prayer"] == str(PrayerTime.FAJR)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -39,6 +39,8 @@ async def test_setup_migrates_legacy_options(hass: HomeAssistant) -> None:
     assert await hass.config_entries.async_setup(entry.entry_id)
     assert REMINDER_MINUTES not in entry.options
     assert entry.options[prayer_reminder_minutes_key(PrayerTime.FAJR)] == 12
+    assert CALCULATION_METHOD not in entry.data
+    assert entry.options[CALCULATION_METHOD] == "mwl"
 
 
 async def test_setup_entry_registers_frontend(hass: HomeAssistant) -> None:

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,0 +1,312 @@
+"""Test in-flow prayer times preview."""
+
+from unittest.mock import MagicMock
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_LATITUDE, CONF_LOCATION, CONF_LONGITUDE, CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.mawaqeet.calculation import (
+    compute_prayer_times_from_options,
+)
+from custom_components.mawaqeet.const import (
+    CALCULATION_METHOD,
+    DOMAIN,
+    MADHAB,
+)
+from custom_components.mawaqeet.enum import CalculationMethod, PrayerTime
+from custom_components.mawaqeet.preview import (
+    async_setup_preview,
+    format_preview_state,
+    ws_start_preview,
+)
+
+
+async def _call_preview(
+    hass: HomeAssistant,
+    connection: MagicMock,
+    msg: dict,
+) -> None:
+    """Invoke the async preview handler (bypass scheduling wrapper)."""
+    await ws_start_preview.__wrapped__(hass, connection, msg)
+
+
+def test_format_preview_state_contains_prayers() -> None:
+    """Test preview state is a compact schedule string."""
+    data = compute_prayer_times_from_options(
+        {CONF_LATITUDE: 51.5074, CONF_LONGITUDE: -0.1278},
+        {CALCULATION_METHOD: "mwl", MADHAB: "shafi"},
+    )
+    state = format_preview_state(data["prayer_times"])
+    assert "Fajr" in state
+    assert "Dhuhr" in state
+    assert "Ishaa" in state
+    assert " · " in state
+
+
+async def test_config_flow_forms_include_preview(hass: HomeAssistant) -> None:
+    """Test calculation and adjustment steps advertise preview."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Home",
+            CONF_LOCATION: {CONF_LATITUDE: 51.5, CONF_LONGITUDE: -0.12},
+        },
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "calculation"
+    assert result.get("preview") == DOMAIN
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CALCULATION_METHOD: "mwl"},
+    )
+    assert result["step_id"] == "adjustment"
+    assert result.get("preview") == DOMAIN
+
+
+async def test_options_flow_forms_include_preview(hass: HomeAssistant) -> None:
+    """Test options calculation and adjustment steps advertise preview."""
+    location = {CONF_LATITUDE: 51.5074, CONF_LONGITUDE: -0.1278}
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Home",
+        unique_id=f"{location[CONF_LATITUDE]:.6f}_{location[CONF_LONGITUDE]:.6f}",
+        data={CONF_NAME: "Home", CONF_LOCATION: location},
+        options={CALCULATION_METHOD: "mwl", MADHAB: "shafi"},
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["step_id"] == "calculation"
+    assert result.get("preview") == DOMAIN
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CALCULATION_METHOD: "isna"},
+    )
+    assert result["step_id"] == "adjustment"
+    assert result.get("preview") == DOMAIN
+    entry.runtime_data.coordinator.clear_event_sub()
+
+
+async def test_ws_preview_config_adjustment(hass: HomeAssistant) -> None:
+    """Test websocket preview returns schedule for config adjustment step."""
+    await async_setup_preview(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Home",
+            CONF_LOCATION: {CONF_LATITUDE: 51.5074, CONF_LONGITUDE: -0.1278},
+        },
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CALCULATION_METHOD: "mwl"},
+    )
+    assert result["step_id"] == "adjustment"
+    flow_id = result["flow_id"]
+
+    messages: list[dict] = []
+
+    def send_message(msg: dict | str | bytes) -> None:
+        if isinstance(msg, dict):
+            messages.append(msg)
+
+    connection = MagicMock()
+    connection.send_message = send_message
+    connection.send_result = MagicMock(
+        side_effect=lambda msg_id, result=None: messages.append(
+            {"id": msg_id, "type": "result", "success": True, "result": result}
+        )
+    )
+    connection.subscriptions = {}
+
+    await _call_preview(
+        hass,
+        connection,
+        {
+            "id": 1,
+            "type": f"{DOMAIN}/start_preview",
+            "flow_type": "config_flow",
+            "flow_id": flow_id,
+            "user_input": {MADHAB: "shafi", "fajr": 0},
+        },
+    )
+
+    events = [m for m in messages if m.get("type") == "event"]
+    assert events
+    preview = events[0]["event"]
+    assert "error" not in preview
+    assert "Fajr" in preview["state"]
+    assert preview["attributes"][str(PrayerTime.FAJR)]
+
+
+async def test_ws_preview_offset_changes_state(hass: HomeAssistant) -> None:
+    """Test changing fajr offset changes preview state."""
+    await async_setup_preview(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Home",
+            CONF_LOCATION: {CONF_LATITUDE: 51.5074, CONF_LONGITUDE: -0.1278},
+        },
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CALCULATION_METHOD: "mwl"},
+    )
+    flow_id = result["flow_id"]
+
+    async def _preview(user_input: dict) -> str:
+        messages: list[dict] = []
+
+        def send_message(msg: dict | str | bytes) -> None:
+            if isinstance(msg, dict):
+                messages.append(msg)
+
+        connection = MagicMock()
+        connection.send_message = send_message
+        connection.send_result = MagicMock(
+            side_effect=lambda msg_id, result=None: messages.append(
+                {"id": msg_id, "type": "result", "success": True, "result": result}
+            )
+        )
+        connection.subscriptions = {}
+        await _call_preview(
+            hass,
+            connection,
+            {
+                "id": 1,
+                "type": f"{DOMAIN}/start_preview",
+                "flow_type": "config_flow",
+                "flow_id": flow_id,
+                "user_input": user_input,
+            },
+        )
+        events = [m for m in messages if m.get("type") == "event"]
+        assert events
+        return events[0]["event"]["state"]
+
+    state_zero = await _preview({MADHAB: "shafi", "fajr": 0})
+    state_shifted = await _preview({MADHAB: "shafi", "fajr": 15})
+    assert state_zero != state_shifted
+
+
+async def test_ws_preview_options_calculation(hass: HomeAssistant) -> None:
+    """Test options calculation-step preview uses entry madhab/offsets."""
+    await async_setup_preview(hass)
+    location = {CONF_LATITUDE: 51.5074, CONF_LONGITUDE: -0.1278}
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Home",
+        unique_id=f"{location[CONF_LATITUDE]:.6f}_{location[CONF_LONGITUDE]:.6f}",
+        data={CONF_NAME: "Home", CONF_LOCATION: location},
+        options={CALCULATION_METHOD: "mwl", MADHAB: "shafi"},
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["step_id"] == "calculation"
+    flow_id = result["flow_id"]
+
+    messages: list[dict] = []
+
+    def send_message(msg: dict | str | bytes) -> None:
+        if isinstance(msg, dict):
+            messages.append(msg)
+
+    connection = MagicMock()
+    connection.send_message = send_message
+    connection.send_result = MagicMock(
+        side_effect=lambda msg_id, result=None: messages.append(
+            {"id": msg_id, "type": "result", "success": True, "result": result}
+        )
+    )
+    connection.subscriptions = {}
+
+    await _call_preview(
+        hass,
+        connection,
+        {
+            "id": 1,
+            "type": f"{DOMAIN}/start_preview",
+            "flow_type": "options_flow",
+            "flow_id": flow_id,
+            "user_input": {CALCULATION_METHOD: "isna"},
+        },
+    )
+
+    events = [m for m in messages if m.get("type") == "event"]
+    assert events
+    preview = events[0]["event"]
+    assert "Fajr" in preview["state"]
+    assert preview["attributes"][CALCULATION_METHOD] == "isna"
+    entry.runtime_data.coordinator.clear_event_sub()
+
+
+async def test_ws_preview_custom_method_seeds_angles(hass: HomeAssistant) -> None:
+    """Test calculation-step custom preview uses non-zero default angles."""
+    await async_setup_preview(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Home",
+            CONF_LOCATION: {CONF_LATITUDE: 51.5074, CONF_LONGITUDE: -0.1278},
+        },
+    )
+    assert result["step_id"] == "calculation"
+    flow_id = result["flow_id"]
+
+    messages: list[dict] = []
+
+    def send_message(msg: dict | str | bytes) -> None:
+        if isinstance(msg, dict):
+            messages.append(msg)
+
+    connection = MagicMock()
+    connection.send_message = send_message
+    connection.send_result = MagicMock(
+        side_effect=lambda msg_id, result=None: messages.append(
+            {"id": msg_id, "type": "result", "success": True, "result": result}
+        )
+    )
+    connection.subscriptions = {}
+
+    await _call_preview(
+        hass,
+        connection,
+        {
+            "id": 1,
+            "type": f"{DOMAIN}/start_preview",
+            "flow_type": "config_flow",
+            "flow_id": flow_id,
+            "user_input": {CALCULATION_METHOD: str(CalculationMethod.CUSTOM)},
+        },
+    )
+
+    events = [m for m in messages if m.get("type") == "event"]
+    assert events
+    preview = events[0]["event"]
+    assert "error" not in preview
+    assert "Fajr" in preview["state"]
+    assert preview["attributes"][CALCULATION_METHOD] == str(CalculationMethod.CUSTOM)


### PR DESCRIPTION
## Summary
- Move calculation method into options (independent of location) with migrate-from-data, and add live prayer-times preview on calculation/adjustment steps.
- Fix prayer-event `device_id` at fire time and strip stale custom angles/interval when leaving custom method; harden HACS zip (strip leading `v`, exclude `frontend/` / `brand/src` / `__pycache__`).
- Lovelace card and docs updates; bump `manifest.json` to **0.4.4**.

## Test plan
- [x] Docker `bash scripts/lint` + `bash scripts/test` (95% cov)
- [x] Docker frontend `npm ci && npm test && npm build`
- [ ] CI green on PR (Test, Lint, Validate, Frontend)
- [ ] After merge to `main`, publish `v0.4.4` and confirm `mawaqeet.zip` asset + packaged manifest version `0.4.4` (no leading `v`)